### PR TITLE
Fix typo

### DIFF
--- a/src/stan-users-guide/truncation-censoring.Rmd
+++ b/src/stan-users-guide/truncation-censoring.Rmd
@@ -192,7 +192,7 @@ probability of
 $$
 \mbox{Pr}[y > U]
 = \int_U^{\infty} \mathsf{normal}(y|\mu,\sigma) \, dy
-= 1 - \Phi\left(\frac{y - \mu}{\sigma}\right),
+= 1 - \Phi\left(\frac{U - \mu}{\sigma}\right),
 $$
 
 where $\Phi()$ is the standard normal cumulative distribution function.
@@ -200,8 +200,8 @@ With $M$ censored observations, the total probability on the log scale
 is
 $$
 \log \prod_{m=1}^M \mbox{Pr}[y_m > U]
-= \log \left( 1 - \Phi\left(\frac{y - \mu}{\sigma}\right)\right)^{M}
-= M \, `normal_lccdf`(y | \mu, \sigma),
+= \log \left( 1 - \Phi\left(\frac{U - \mu}{\sigma}\right)\right)^{M}
+= M \, `normal_lccdf`(U | \mu, \sigma),
 $$
 
 where `normal_lccdf` is the log of complementary CDF


### PR DESCRIPTION
#### Submission Checklist

- [ ] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

`\int_U^{\infty} \mathsf{normal}(y|\mu,\sigma) \, dy` should be `1 - \Phi\left(\frac{U - \mu}{\sigma}\right)` because `y` was integrated out.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Takamasa Oshikiri

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
