### PR TITLE
Fix operator precedence in reference manual (#27)

### DIFF
--- a/src/reference-manual/expressions.Rmd
+++ b/src/reference-manual/expressions.Rmd
@@ -530,15 +530,15 @@ associativity.*
 `+` | 5 | left | binary infix | addition
 `-` | 5 | left | binary infix | subtraction
 `*` | 4 | left | binary infix | multiplication
+`.*` | 4 | left | binary infix | elementwise multiplication
 `/` | 4 | left | binary infix | (right) division
+`./` | 4 | left | binary infix | elementwise division
 `%` | 4 | left | binary infix | modulus
 `\` | 3 | left | binary infix | left division
-`.*` | 2 | left | binary infix | elementwise multiplication
-`./` | 2 | left | binary infix | elementwise division
-`!` | 1 | n/a | unary prefix | logical negation
-`-` | 1 | n/a | unary prefix | negation
-`+` | 1 | n/a | unary prefix | promotion (no-op in Stan)
-`^` | 0.5 | right | binary infix | exponentiation
+`!` | 2 | n/a | unary prefix | logical negation
+`-` | 2 | n/a | unary prefix | negation
+`+` | 2 | n/a | unary prefix | promotion (no-op in Stan)
+`^` | 1 | right | binary infix | exponentiation
 `'` | 0 | n/a | unary postfix | transposition
 `()` | 0 | n/a | prefix, wrap | function application
 `[]` | 0 | left | prefix, wrap | array, matrix indexing


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
As suggested in #27, the `.*` and `./` operators should have the same precedence as `*` and `/` (4 in the table). So as not to leave gaps in the numbers listed in the precedence column, I've also changed the 1s to 2s and the 0.5 to 1, which I think is clearer anyway.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
