### PR TITLE
Typos in reference manual and user's guide

### DIFF
--- a/src/reference-manual/expressions.Rmd
+++ b/src/reference-manual/expressions.Rmd
@@ -185,7 +185,7 @@ The legal characters for variable identifiers are given in the
 [identifier characters table](#identifier-characters-table).
 
 **Identifier Characters Table.** id:identifier-characters-table
-*The alpanumeric characters and underscore in base ASCII are the only
+*The alphanumeric characters and underscore in base ASCII are the only
 legal characters in Stan identifiers.*
 
  characters |  ASCII code points

--- a/src/reference-manual/statements.Rmd
+++ b/src/reference-manual/statements.Rmd
@@ -891,7 +891,7 @@ for (y in yss)
 In both cases, the loop variable `y` is of type `real.  The elements
 of the matrix are visited in column-major order (e.g., `y[1, 1]`,
 `y[2, 1]`, `y[1, 2]`, ..., `y[2, 3]`), whereas the elements of the
-two-dimensionl array are visited in row-major order (e.g., `y[1, 1]`,
+two-dimensional array are visited in row-major order (e.g., `y[1, 1]`,
 `y[1, 2]`, `y[1, 3]`, `y[2, 1]`, ..., `y[2, 3]`).
 
 
@@ -922,7 +922,7 @@ The entire sequence of if-then-else clauses forms a single conditional
 statement for evaluation.  The conditions are evaluated in order
 until one of the conditions evaluates to a non-zero value, at which
 point its corresponding statement is executed and the conditional
-statement finishes execution.  If none of the conditions evaluates to
+statement finishes execution.  If none of the conditions evaluate to
 a non-zero value and there is a final else clause, its statement is
 executed.
 

--- a/src/reference-manual/types.Rmd
+++ b/src/reference-manual/types.Rmd
@@ -247,7 +247,7 @@ int<lower=0,upper=1> cond;
 ### Unconstrained Real {-}
 
 Unconstrained real variables are declared using the keyword
-`real`, The following example declares `theta` to be an
+`real`. The following example declares `theta` to be an
 unconstrained continuous value.
 
 ```stan
@@ -728,7 +728,7 @@ A Cholesky factor $L$ is an $M \times N$ lower-triangular matrix (if
 $m < n$ then $L[m, n] =0$) with a strictly positive diagonal ($L[k, k]
 > 0$) and $M \geq N$.  If $L$ is a Cholesky factor, then $\Sigma = L
 \, L^{\top}$ is a covariance matrix (i.e., it is positive definite).
-The mapping between positive definite matrixes and their Cholesky
+The mapping between positive definite matrices and their Cholesky
 factors is bijective---every covariance matrix has a unique Cholesky
 factorization.
 

--- a/src/stan-users-guide/algebraic-equations.Rmd
+++ b/src/stan-users-guide/algebraic-equations.Rmd
@@ -2,7 +2,7 @@
 
 Stan provides a built-in mechanism for specifying and solving systems
 of algebraic equations, using the Powell hybrid method [@Powell:1970].
-The function signatures for Stan's algebraic solver aref ully
+The function signatures for Stan's algebraic solver are fully
 described in the algebraic solver section of the reference manual.
 
 Solving any system of algebraic equations can be translated into a root-finding

--- a/src/stan-users-guide/finite-mixtures.Rmd
+++ b/src/stan-users-guide/finite-mixtures.Rmd
@@ -622,7 +622,7 @@ The Bernoulli statements are just shorthand for adding $\log \theta$
 and $\log (1 - \theta)$ to the log density.  The `T[1,]` after the
 Poisson indicates that it is truncated below at 1; see the [truncation
 section](#truncation.section) for more about truncation and the
-[Poisson regresison section](#poisson.section) for the specifics of
+[Poisson regression section](#poisson.section) for the specifics of
 the Poisson CDF.  The net effect is equivalent to the direct
 definition of the log likelihood.
 

--- a/src/stan-users-guide/floating-point.Rmd
+++ b/src/stan-users-guide/floating-point.Rmd
@@ -80,7 +80,7 @@ Not-a-number values propagate under almost all mathematical
 operations.  For example, all of the built-in binary arithmetic
 operations (addition, subtraction, multiplication, division, negation)
 return not-a-number if any of their arguments are not-a-number.  The
-built-in functions such as `log` and `exp` hav the same behavior,
+built-in functions such as `log` and `exp` have the same behavior,
 propagating not-a-number values.
 
 Most of Stan's built-in functions will throw exceptions (i.e., reject)

--- a/src/stan-users-guide/hyperspherical-models.Rmd
+++ b/src/stan-users-guide/hyperspherical-models.Rmd
@@ -174,7 +174,7 @@ It might be tempting to try to just declare theta directly as a
 parameter with the lower and upper bound constraint as given above.
 The drawback to this approach is that the values $-\pi$ and $\pi$ are
 at $-\infty$ and $\infty$ on the unconstrained scale, which can
-produce multimodal posterior distribtions when the true distribution
+produce multimodal posterior distributions when the true distribution
 on the circle is unimodal.
 
 With a little additional work on the trigonometric front, the same

--- a/src/stan-users-guide/latent-discrete.Rmd
+++ b/src/stan-users-guide/latent-discrete.Rmd
@@ -527,7 +527,7 @@ $\phi_t$, not being captured in the next time period with probability
 $(1 - p_{t+1})$, and not being captured again after being alive in
 period $t+1$ with probability $\chi_{t+1}$.
 
-With three capture times, there are three captured/not-captured
+With three capture times, there are eight captured/not-captured
 profiles an individual may have.  These may be naturally coded as
 binary numbers as follows.
 
@@ -886,8 +886,8 @@ challenge in the modeling for Stan is to marginalize out the discrete
 parameters.
 
 @DawidSkene:1979 introduce a noisy-measurement model for
-coding and apply it in the epidemiologial setting of coding what
-doct@s say aboutpatient histories;  the same model can be used
+coding and apply it in the epidemiological setting of coding what
+doctors say about patient histories;  the same model can be used
 for diagnostic procedures.
 
 #### Data {-}

--- a/src/stan-users-guide/map-reduce.Rmd
+++ b/src/stan-users-guide/map-reduce.Rmd
@@ -46,7 +46,7 @@ is reused in each mapped operation.
 
 The `_rect` suffix in the name arises because the data
 structures it takes as arguments are rectangular.  In order to deal
-with ragged inputs, ragged inputs must be padded out to recangular
+with ragged inputs, ragged inputs must be padded out to rectangular
 form.
 
 The last two arguments are two dimensional arrays of real and integer
@@ -65,7 +65,7 @@ vector f(vector phi, vector theta,
 ```
 
 Although `f` will often return a vector of size one, the built-in
-flexiblity allows general multivariate functions to be mapped, even
+flexibility allows general multivariate functions to be mapped, even
 raggedly.
 
 ### Map Function Semantics {-}

--- a/src/stan-users-guide/matrices-arrays.Rmd
+++ b/src/stan-users-guide/matrices-arrays.Rmd
@@ -312,7 +312,7 @@ u = [1,3,9,27]
 x = [1,3,6,9]
 ```
 
-In the loop version assiging to `u`, the values are updated before being used to
-define subseqeunt values;  in the sliced expression assigning to
+In the loop version assigning to `u`, the values are updated before being used to
+define subsequent values;  in the sliced expression assigning to
 `x`, the entire right-hand side is evaluated before assigning to
 the left-hand side.

--- a/src/stan-users-guide/one-dimensional-integrals.Rmd
+++ b/src/stan-users-guide/one-dimensional-integrals.Rmd
@@ -57,7 +57,7 @@ the truncation limit is to be estimated as a parameter. Because the truncation
 point is a parameter, we must include the normalization term of the truncated pdf when
 computing our model's log density. Note this is just an example of how to use the
 1D integrator. The more efficient way to perform the correct normalization in Stan
-is described in the chapter on Truncated or Censorsored Data of this guide.
+is described in the chapter on Truncated or Censored Data of this guide.
 
 Such a model might look like (include the function defined at the beginning of this
 chapter to make this code compile):
@@ -107,7 +107,7 @@ must be expressions that only involve data or transformed data variables.
 `theta`, on the other hand, can be a function of data, transformed data,
 parameters, or transformed parameters.
 
-The endpoints of integration can be data or parameters (and interally the
+The endpoints of integration can be data or parameters (and internally the
 derivatives of the integral with respect to the endpoints are handled
 with the Leibniz integral rule).
 

--- a/src/stan-users-guide/regression.Rmd
+++ b/src/stan-users-guide/regression.Rmd
@@ -152,7 +152,7 @@ In the previous example, the linear predictor can be written as $\eta
 Presuming $N \geq K$, we can exploit the fact that any design matrix,
 $x$ can be decomposed using the thin QR decomposition into an
 orthogonal matrix $Q$ and an upper-triangular matrix $R$, i.e. $x = Q
-R$.  See the reference manual for a definition of the QR-decoposition.
+R$.  See the reference manual for a definition of the QR-decomposition.
 The functions `qr_Q` and `qr_R` implement the fat QR decomposition so
 here we thin it by including only $K$ columns in $Q$ and $K$ rows in
 $R$ (see the reference manual for more information on the `qr_Q` and
@@ -1380,7 +1380,7 @@ output `Sigma`, define it as a transformed parameter.  The function
 equivalent to `diag_matrix(tau) * Sigma * diag_matrix(tau)`, where
 `diag_matrix(tau)` returns the matrix with `tau` on the diagonal and
 zeroes off diagonal; the version using `quad_form_diag` should be
-faster.  For details on these and other matrix arithmtic operators and
+faster.  For details on these and other matrix arithmetic operators and
 functions, see the function reference manual.
 
 #### Optimization through Vectorization {-}
@@ -1542,7 +1542,7 @@ model {
 }
 ```
 
-This model also reparameterizes the prior scale `tau` to avoid potential problems with the heavy tails of the Cauchy distribution. The statement `tau_unif ~ uniform(0,pi()/2)` can be omitted from the model block because stan increments the log posterior for parameters with uniform priors without it.
+This model also reparameterizes the prior scale `tau` to avoid potential problems with the heavy tails of the Cauchy distribution. The statement `tau_unif ~ uniform(0,pi()/2)` can be omitted from the model block because Stan increments the log posterior for parameters with uniform priors without it.
 
 ## Prediction, Forecasting, and Backcasting
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
This fixes various typos.

The only sort of non-typo is the one in `stan-users-guide/latent-discrete.Rmd`, where there's a change `three` to `eight`, as with 3 capture times there are `2^3=8` captured/not-captured profiles.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
