### PR TITLE
Fix unit vector absolute jacobian determinant equation

### DIFF
--- a/src/reference-manual/transforms.Rmd
+++ b/src/reference-manual/transforms.Rmd
@@ -692,7 +692,7 @@ $y$. Thus, there technically is no unique transformation from $x$ to
 $y$. To circumvent this issue, let $r = \sqrt{y^\top y}$ so that $y = r
 x$. The transformation from $\left(r, x_{-n}\right)$ to $y$ is
 well-defined but $r$ is arbitrary, so we set $r = 1$. In this case,
-the determinant of the Jacobian is proportional to $-\frac{1}{2} y^\top y$,
+the determinant of the Jacobian is proportional to $e^{-\frac{1}{2} y^\top y}$,
 which is the kernel of a standard multivariate normal distribution
 with $n$ independent dimensions.
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Unit vector absolute Jacobian determinant documentation gave the _logarithm_ of the absolute Jacobian determinant. This corrects the equation.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Seth Axen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
