### PR TITLE
use a consistent name for the outcome variable in the negative binomial sections

### DIFF
--- a/src/functions-reference/unbounded_discrete_distributions.Rmd
+++ b/src/functions-reference/unbounded_discrete_distributions.Rmd
@@ -23,21 +23,21 @@ section [negative binomial glm](#neg-binom-2-log).
 
 ### Probability Mass Function
 
-If $\alpha \in \mathbb{R}^+$ and $\beta \in \mathbb{R}^+$, then for $y
-\in \mathbb{N}$, \[ \text{NegBinomial}(y~|~\alpha,\beta)  = \binom{y +
+If $\alpha \in \mathbb{R}^+$ and $\beta \in \mathbb{R}^+$, then for $n
+\in \mathbb{N}$, \[ \text{NegBinomial}(n~|~\alpha,\beta) = \binom{n +
 \alpha - 1}{\alpha - 1} \, \left( \frac{\beta}{\beta+1}
-\right)^{\!\alpha} \, \left( \frac{1}{\beta + 1} \right)^{\!y} \!. \]
+\right)^{\!\alpha} \, \left( \frac{1}{\beta + 1} \right)^{\!n} \!. \]
 
-The mean and variance of a random variable $y \sim
-\text{NegBinomial}(\alpha,\beta)$ are given by \[ \mathbb{E}[y] =
-\frac{\alpha}{\beta} \ \ \text{ and } \ \ \text{Var}[Y] =
+The mean and variance of a random variable $n \sim
+\text{NegBinomial}(\alpha,\beta)$ are given by \[ \mathbb{E}[n] =
+\frac{\alpha}{\beta} \ \ \text{ and } \ \ \text{Var}[n] =
 \frac{\alpha}{\beta^2} (\beta + 1). \]
 
 ### Sampling Statement
 
 `n ~ ` **`neg_binomial`**`(alpha, beta)`
 
-Increment target log probability density with `neg_binomial_lpmf( n | alpha, beta)`
+Increment target log probability density with `neg_binomial_lpmf(n | alpha, beta)`
 dropping constant additive terms.
 <!-- real; neg_binomial ~; -->
 \index{{\tt \bfseries neg\_binomial }!sampling statement|hyperpage}
@@ -48,37 +48,37 @@ dropping constant additive terms.
 \index{{\tt \bfseries neg\_binomial\_lpmf }!{\tt (ints n \textbar\ reals alpha, reals beta): real}|hyperpage}
 
 `real` **`neg_binomial_lpmf`**`(ints n | reals alpha, reals beta)`<br>\newline
-The log negative binomial probability mass of n given shape alpha and
-inverse scale beta
+The log negative binomial probability mass of `n` given shape `alpha` and
+inverse scale `beta`
 
 <!-- real; neg_binomial_cdf; (ints n, reals alpha, reals beta); -->
 \index{{\tt \bfseries neg\_binomial\_cdf }!{\tt (ints n, reals alpha, reals beta): real}|hyperpage}
 
 `real` **`neg_binomial_cdf`**`(ints n, reals alpha, reals beta)`<br>\newline
-The negative binomial cumulative distribution function of n given
-shape alpha and inverse scale beta
+The negative binomial cumulative distribution function of `n` given
+shape `alpha` and inverse scale `beta`
 
 <!-- real; neg_binomial_lcdf; (ints n | reals alpha, reals beta); -->
 \index{{\tt \bfseries neg\_binomial\_lcdf }!{\tt (ints n \textbar\ reals alpha, reals beta): real}|hyperpage}
 
 `real` **`neg_binomial_lcdf`**`(ints n | reals alpha, reals beta)`<br>\newline
-The log of the negative binomial cumulative distribution function of n
-given shape alpha and inverse scale beta
+The log of the negative binomial cumulative distribution function of `n`
+given shape `alpha` and inverse scale `beta`
 
 <!-- real; neg_binomial_lccdf; (ints n | reals alpha, reals beta); -->
 \index{{\tt \bfseries neg\_binomial\_lccdf }!{\tt (ints n \textbar\ reals alpha, reals beta): real}|hyperpage}
 
 `real` **`neg_binomial_lccdf`**`(ints n | reals alpha, reals beta)`<br>\newline
 The log of the negative binomial complementary cumulative distribution
-function of n given shape alpha and inverse scale beta
+function of `n` given shape `alpha` and inverse scale `beta`
 
 <!-- R; neg_binomial_rng; (reals alpha, reals beta); -->
 \index{{\tt \bfseries neg\_binomial\_rng }!{\tt (reals alpha, reals beta): R}|hyperpage}
 
 `R` **`neg_binomial_rng`**`(reals alpha, reals beta)`<br>\newline
-Generate a negative binomial variate with shape alpha and inverse
-scale beta; may only be used in generated quantities block. alpha $/$
-beta must be less than $2 ^ {29}$. For a description of argument and
+Generate a negative binomial variate with shape `alpha` and inverse
+scale `beta`; may only be used in generated quantities block. `alpha` $/$
+`beta` must be less than $2 ^ {29}$. For a description of argument and
 return types, see section [vectorized function signatures](#prob-vectorization).
 
 ## Negative Binomial Distribution (alternative parameterization) {#nbalt}
@@ -92,14 +92,14 @@ alternative parameterization directly in terms of the log mean.
 ### Probability Mass Function
 
 The first parameterization is for $\mu \in \mathbb{R}^+$ and $\phi \in
-\mathbb{R}^+$, which for $y \in \mathbb{N}$ is defined as \[
-\text{NegBinomial2}(y \, | \, \mu, \phi)  = \binom{y + \phi - 1}{y} \,
+\mathbb{R}^+$, which for $n \in \mathbb{N}$ is defined as \[
+\text{NegBinomial2}(n \, | \, \mu, \phi)  = \binom{n + \phi - 1}{y} \,
 \left( \frac{\mu}{\mu+\phi} \right)^{\!y} \, \left(
 \frac{\phi}{\mu+\phi} \right)^{\!\phi} \!. \]
 
-The mean and variance of a random variable $y \sim
-\text{NegBinomial2}(y~|~\mu,\phi)$ are \[ \mathbb{E}[Y] = \mu \ \ \
-\text{ and } \ \ \ \text{Var}[Y] = \mu + \frac{\mu^2}{\phi}. \] Recall
+The mean and variance of a random variable $n \sim
+\text{NegBinomial2}(n~|~\mu,\phi)$ are \[ \mathbb{E}[n] = \mu \ \ \
+\text{ and } \ \ \ \text{Var}[n] = \mu + \frac{\mu^2}{\phi}. \] Recall
 that $\text{Poisson}(\mu)$ has variance $\mu$, so $\mu^2 / \phi > 0$
 is the additional variance of the negative binomial above that of the
 Poisson with mean $\mu$.  So the inverse of parameter $\phi$ controls
@@ -107,49 +107,49 @@ the overdispersion, scaled by the square of the mean, $\mu^2$.
 
 ### Sampling Statement
 
-`y ~ ` **`neg_binomial_2`**`(mu, phi)`
+`n ~ ` **`neg_binomial_2`**`(mu, phi)`
 
-Increment target log probability density with `neg_binomial_2_lpmf( y | mu, phi)`
+Increment target log probability density with `neg_binomial_2_lpmf(n | mu, phi)`
 dropping constant additive terms.
 <!-- real; neg_binomial_2 ~; -->
 \index{{\tt \bfseries neg\_binomial\_2 }!sampling statement|hyperpage}
 
 ### Stan Functions
 
-<!-- real; neg_binomial_2_lpmf; (ints y | reals mu, reals phi); -->
-\index{{\tt \bfseries neg\_binomial\_2\_lpmf }!{\tt (ints y \textbar\ reals mu, reals phi): real}|hyperpage}
+<!-- real; neg_binomial_2_lpmf; (ints n | reals mu, reals phi); -->
+\index{{\tt \bfseries neg\_binomial\_2\_lpmf }!{\tt (ints n \textbar\ reals mu, reals phi): real}|hyperpage}
 
-`real` **`neg_binomial_2_lpmf`**`(ints y | reals mu, reals phi)`<br>\newline
-The negative binomial probability mass of n given location mu and
-precision phi.
+`real` **`neg_binomial_2_lpmf`**`(ints n | reals mu, reals phi)`<br>\newline
+The negative binomial probability mass of `n` given location `mu` and
+precision `phi`.
 
 <!-- real; neg_binomial_2_cdf; (ints n, reals mu, reals phi); -->
 \index{{\tt \bfseries neg\_binomial\_2\_cdf }!{\tt (ints n, reals mu, reals phi): real}|hyperpage}
 
 `real` **`neg_binomial_2_cdf`**`(ints n, reals mu, reals phi)`<br>\newline
-The negative binomial cumulative distribution function of n given
-location mu and precision phi.
+The negative binomial cumulative distribution function of `n` given
+location `mu` and precision `phi`.
 
 <!-- real; neg_binomial_2_lcdf; (ints n | reals mu, reals phi); -->
 \index{{\tt \bfseries neg\_binomial\_2\_lcdf }!{\tt (ints n \textbar\ reals mu, reals phi): real}|hyperpage}
 
 `real` **`neg_binomial_2_lcdf`**`(ints n | reals mu, reals phi)`<br>\newline
-The log of the negative binomial cumulative distribution function of n
-given location mu and precision phi.
+The log of the negative binomial cumulative distribution function of `n`
+given location `mu` and precision `phi`.
 
 <!-- real; neg_binomial_2_lccdf; (ints n | reals mu, reals phi); -->
 \index{{\tt \bfseries neg\_binomial\_2\_lccdf }!{\tt (ints n \textbar\ reals mu, reals phi): real}|hyperpage}
 
 `real` **`neg_binomial_2_lccdf`**`(ints n | reals mu, reals phi)`<br>\newline
 The log of the negative binomial complementary cumulative distribution
-function of n given location mu and precision phi.
+function of `n` given location `mu` and precision `phi`.
 
 <!-- R; neg_binomial_2_rng; (reals mu, reals phi); -->
 \index{{\tt \bfseries neg\_binomial\_2\_rng }!{\tt (reals mu, reals phi): R}|hyperpage}
 
 `R` **`neg_binomial_2_rng`**`(reals mu, reals phi)`<br>\newline
-Generate a negative binomial variate with location mu and precision
-phi; may only be used in generated quantities block. mu must be less
+Generate a negative binomial variate with location `mu` and precision
+`phi`; may only be used in generated quantities block. `mu` must be less
 than $2 ^ {29}$. For a description of argument and return types, see
 section [vectorized function signatures](#prob-vectorization).
 
@@ -157,38 +157,38 @@ section [vectorized function signatures](#prob-vectorization).
 
 Related to the parameterization in section [negative binomial, alternative parameterization](#nbalt), the following
 parameterization uses a log mean parameter $\eta = \log(\mu)$, defined
-for $\eta \in \mathbb{R}$, $\phi \in \mathbb{R}^+$, so that for $y \in
-\mathbb{N}$, \[ \text{NegBinomial2Log}(y \, | \, \eta, \phi) =
-\text{NegBinomial2}(y | \exp(\eta), \phi). \] This alternative may be
+for $\eta \in \mathbb{R}$, $\phi \in \mathbb{R}^+$, so that for $n \in
+\mathbb{N}$, \[ \text{NegBinomial2Log}(n \, | \, \eta, \phi) =
+\text{NegBinomial2}(n | \exp(\eta), \phi). \] This alternative may be
 used for sampling, as a function, and for random number generation,
 but as of yet, there are no CDFs implemented for it.
 
 ### Sampling Statement
 
-`y ~ ` **`neg_binomial_2_log`**`(eta, phi)`
+`n ~ ` **`neg_binomial_2_log`**`(eta, phi)`
 
-Increment target log probability density with `neg_binomial_2_log_lpmf( y | eta, phi)`
+Increment target log probability density with `neg_binomial_2_log_lpmf(n | eta, phi)`
 dropping constant additive terms.
 <!-- real; neg_binomial_2_log ~; -->
 \index{{\tt \bfseries neg\_binomial\_2\_log }!sampling statement|hyperpage}
 
 ### Stan Functions
 
-<!-- real; neg_binomial_2_log_lpmf; (ints y | reals eta, reals phi); -->
-\index{{\tt \bfseries neg\_binomial\_2\_log\_lpmf }!{\tt (ints y \textbar\ reals eta, reals phi): real}|hyperpage}
+<!-- real; neg_binomial_2_log_lpmf; (ints n | reals eta, reals phi); -->
+\index{{\tt \bfseries neg\_binomial\_2\_log\_lpmf }!{\tt (ints n \textbar\ reals eta, reals phi): real}|hyperpage}
 
-`real` **`neg_binomial_2_log_lpmf`**`(ints y | reals eta, reals phi)`<br>\newline
-The log negative binomial probability mass of n given log-location eta
-and inverse overdispersion control phi. This is especially useful for
+`real` **`neg_binomial_2_log_lpmf`**`(ints n | reals eta, reals phi)`<br>\newline
+The log negative binomial probability mass of `n` given log-location `eta`
+and inverse overdispersion control `phi`. This is especially useful for
 log-linear negative binomial regressions.
 
 <!-- R; neg_binomial_2_log_rng; (reals eta, reals phi); -->
 \index{{\tt \bfseries neg\_binomial\_2\_log\_rng }!{\tt (reals eta, reals phi): R}|hyperpage}
 
 `R` **`neg_binomial_2_log_rng`**`(reals eta, reals phi)`<br>\newline
-Generate a negative binomial variate with log-location eta and inverse
-overdispersion control phi; may only be used in generated quantities
-block. eta must be less than $29 \log 2$. For a description of
+Generate a negative binomial variate with log-location `eta` and inverse
+overdispersion control `phi`; may only be used in generated quantities
+block. `eta` must be less than $29 \log 2$. For a description of
 argument and return types, see section [vectorized function signatures](#prob-vectorization).
 
 ## Negative-Binomial-2-Log Generalised Linear Model (Negative Binomial Regression) {#neg-binom-2-log-glm}
@@ -223,7 +223,7 @@ dropping constant additive terms.
 \index{{\tt \bfseries neg\_binomial\_2\_log\_glm\_lpmf }!{\tt (int[] y \textbar\ matrix x, real alpha, vector beta, real phi): real}|hyperpage}
 
 `real` **`neg_binomial_2_log_glm_lpmf`**`(int[] y | matrix x, real alpha, vector beta, real phi)`<br>\newline
-The log negative binomial probability mass of y given log-location
+The log negative binomial probability mass of `y` given log-location
 `alpha+x*beta` and inverse overdispersion control `phi`, where a
 constant intercept `alpha` and `phi` is used for all observations. The
 number of rows of the independent variable matrix `x` needs to match
@@ -234,7 +234,7 @@ columns of `x` needs to match the length of the weight vector `beta`.
 \index{{\tt \bfseries neg\_binomial\_2\_log\_glm\_lpmf }!{\tt (int[] y \textbar\ matrix x, vector alpha, vector beta, real phi): real}|hyperpage}
 
 `real` **`neg_binomial_2_log_glm_lpmf`**`(int[] y | matrix x, vector alpha, vector beta, real phi)`<br>\newline
-The log negative binomial probability mass of y given log-location
+The log negative binomial probability mass of `y` given log-location
 `alpha+x*beta` and inverse overdispersion control `phi`, where a
 constant `phi` is used for all observations and an intercept `alpha`
 is used that is allowed to vary with the different observations. The


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
Fixes #80. I went for using `n` in all sections but the GLM section, where I kept`y`. This was for consistency for the Poisson pages, where the same happened (I assume because there `n` is used to index over the outcome vector). `n` is also the name of the outcome variable used in the chapter on bounded discrete distributions.

I've also put backticks around variable names referenced in the text, as this is done in other places (not consistently, but I think it's right).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
