### PR TITLE
Fix formatting inside formula in the users guide

### DIFF
--- a/src/stan-users-guide/truncation-censoring.Rmd
+++ b/src/stan-users-guide/truncation-censoring.Rmd
@@ -200,7 +200,7 @@ is
 $$
 \log \prod_{m=1}^M \mbox{Pr}[y_m > U]
 = \log \left( 1 - \Phi\left(\frac{U - \mu}{\sigma}\right)\right)^{M}
-= M \, `normal_lccdf`(U | \mu, \sigma),
+= M \, \mathsf{normal_lccdf}(U | \mu, \sigma),
 $$
 
 where `normal_lccdf` is the log of complementary CDF


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
Fixed a use of the markdown backticks inside a latex formula.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
