### PR TITLE
Document what happens to the von Mises distribution for kappa = 0

### DIFF
--- a/src/functions-reference/circular_distributions.Rmd
+++ b/src/functions-reference/circular_distributions.Rmd
@@ -21,15 +21,19 @@ interval  $(c, c + 2\pi)$ of length $2 \pi$, because \[ \int_{c}^{c +
 2\pi} \text{VonMises}(y|\mu,\kappa) dy = 1. \] Similarly, if $\mu$ is
 a parameter, it will typically be restricted to the same range as $y$.
 
-A von Mises distribution with its $2 \pi$ interval of support centered
-around its location $\mu$ will have a single mode at $\mu$; for
-example, restricting $y$ to $(-\pi,\pi)$ and taking $\mu = 0$ leads to
-a single local optimum at the model $\mu$.  If the location $\mu$ is
+If $\kappa > 0$, a von Mises distribution with its $2 \pi$ interval of
+support centered around its location $\mu$ will have a single mode at $\mu$;
+for example, restricting $y$ to $(-\pi,\pi)$ and taking $\mu = 0$ leads to
+a single local optimum at the mode $\mu$.  If the location $\mu$ is
 not in the center of the support, the density is circularly translated
 and there will be a second local maximum at the boundary furthest from
 the mode.  Ideally, the parameterization and support will be set up so
 that the bulk of the probability mass is in a continuous interval
 around the mean $\mu$.
+
+For $\kappa = 0$, the Von Mises distribution corresponds to the
+circular uniform distribution with density $1 / (2 \pi)$ (independently
+of the values of $y$ or $\mu$).
 
 ### Sampling Statement
 
@@ -63,7 +67,7 @@ blocks. For a description of argument and return types, see section
 ### Numerical Stability
 
 Evaluating the Von Mises distribution for $\kappa > 100$ is
-numerically unstable in the current implementation.  Nathanael I.\
+numerically unstable in the current implementation.  Nathanael I.
 Lichti suggested the following workaround on the Stan users group,
 based on the fact that as $\kappa \rightarrow \infty$, \[
 \text{VonMises}(y|\mu,\kappa) \rightarrow \text{Normal}(\mu, \sqrt{1 /


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
Updates documentation to the changes introduced by https://github.com/stan-dev/math/pull/1551, that added support for `kappa = 0` in the von Mises functions.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
