### PR TITLE
Fix description of arguments of csr_to_dense_matrix

### DIFF
--- a/src/functions-reference/sparse_matrix_operations.Rmd
+++ b/src/functions-reference/sparse_matrix_operations.Rmd
@@ -97,8 +97,9 @@ entries w, column indices v, and row starting indices u; the vector w
 and array v must be the same size (corresponding to the total number of
 nonzero entries in the matrix), array v must have index values bounded
 by m, array u must have length equal to m + 1 and contain index values
-bounded by n (except for the last entry, which should be equal to one plus
-the length of w). See section [compressed row storage](#CSR) for more details.
+bounded by the number of nonzeros (except for the last entry, which should
+be equal to the number of nonzeros plus one). See section
+[compressed row storage](#CSR) for more details.
 
 ## Sparse Matrix Arithmetic
 

--- a/src/functions-reference/sparse_matrix_operations.Rmd
+++ b/src/functions-reference/sparse_matrix_operations.Rmd
@@ -94,9 +94,11 @@ a single function.
 `matrix` **`csr_to_dense_matrix`**`(int m, int n, vector w, int[] v, int[] u)`<br>\newline
 Return dense $\text{m} \times \text{n}$ matrix with non-zero matrix
 entries w, column indices v, and row starting indices u; the vector w
-and arrays v and u must all be the same size, and the arrays v and u
-must have index values bounded by m and n. see section [compressed row storage](#CSR) for
-more details.
+and array v must be the same size (corresponding to the total number of
+nonzero entries in the matrix), array v must have index values bounded
+by m, array u must have length equal to m + 1 and contain index values
+bounded by n (except for the last entry, which should be equal to one plus
+the length of w). See section [compressed row storage](#CSR) for more details.
 
 ## Sparse Matrix Arithmetic
 
@@ -116,4 +118,3 @@ rather than $A$ as a sparse matrix.
 Multiply the $\text{m} \times \text{n}$ matrix represented by values
 w, column indices v, and row start indices u by the vector b; see
 [compressed row storage](#CSR).
-

--- a/src/functions-reference/sparse_matrix_operations.Rmd
+++ b/src/functions-reference/sparse_matrix_operations.Rmd
@@ -97,7 +97,7 @@ entries w, column indices v, and row starting indices u; the vector w
 and array v must be the same size (corresponding to the total number of
 nonzero entries in the matrix), array v must have index values bounded
 by m, array u must have length equal to m + 1 and contain index values
-bounded by the number of nonzeros (except for the last entry, which should
+bounded by the number of nonzeros (except for the last entry, which must
 be equal to the number of nonzeros plus one). See section
 [compressed row storage](#CSR) for more details.
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
The documentation of `csr_to_dense_matrix` claims that the length of `v` and `u` should be the same, but that's not correct.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
