### PR TITLE
Fix signature of log_falling_factorial and log_rising_factorial

### DIFF
--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -1010,12 +1010,12 @@ This function generalizes to real numbers using the gamma function.
 For $0 \leq y \leq x$, \[ \mathrm{binomial\_coefficient\_log}(x,y) =
 \log\Gamma(x+1) - \log\Gamma(y+1) - \log\Gamma(x-y+1). \]
 
-<!-- real; log_falling_factorial; (real x, int n); -->
-\index{{\tt \bfseries log\_falling\_factorial }!{\tt (real x, int n): real}|hyperpage}
+<!-- real; log_falling_factorial; (real x, real n); -->
+\index{{\tt \bfseries log\_falling\_factorial }!{\tt (real x, real n): real}|hyperpage}
 
-`real` **`log_falling_factorial`**`(real x, int n)`<br>\newline
+`real` **`log_falling_factorial`**`(real x, real n)`<br>\newline
 Return the log of the falling factorial of x with power n defined for
-positive x and integer n. \[ \mathrm{log\_falling\_factorial}(x,n) =
+positive x and real n. \[ \mathrm{log\_falling\_factorial}(x,n) =
 \begin{cases} \log (x)_n & \text{if } x > 0 \\ \textrm{error} &
 \text{if } x \leq 0 \end{cases} \]
 
@@ -1028,12 +1028,12 @@ and integer n. \[ \mathrm{rising\_factorial}(x,n) = \begin{cases} x^{(n)}
 & \text{if } x > 0 \\ \textrm{error} & \text{if } x \leq 0 \end{cases}
 \] where \[ x^{(n)}=\frac{\Gamma(x+n)}{\Gamma(x)} \]
 
-<!-- real; log_rising_factorial; (real x, int n); -->
+<!-- real; log_rising_factorial; (real x, real n); -->
 \index{{\tt \bfseries log\_rising\_factorial }!{\tt (real x, real n): real}|hyperpage}
 
-`real` **`log_rising_factorial`**`(real x, int n)`<br>\newline
+`real` **`log_rising_factorial`**`(real x, real n)`<br>\newline
 Return the log of the rising factorial of x with power n defined for
-positive x and integer n. \[ \mathrm{log\_rising\_factorial}(x,n) =
+positive x and real n. \[ \mathrm{log\_rising\_factorial}(x,n) =
 \begin{cases} \log x^{(n)} & \text{if } x > 0 \\ \textrm{error} &
 \text{if } x \leq 0 \end{cases} \]
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
This undoes some of my changes from #94, as `log_falling/rising_factorial` takes a real `n`, not int. Sorry about that!

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
