### PR TITLE
correct y to n in NegBinomial2 density

### DIFF
--- a/src/functions-reference/unbounded_discrete_distributions.Rmd
+++ b/src/functions-reference/unbounded_discrete_distributions.Rmd
@@ -93,8 +93,8 @@ alternative parameterization directly in terms of the log mean.
 
 The first parameterization is for $\mu \in \mathbb{R}^+$ and $\phi \in
 \mathbb{R}^+$, which for $n \in \mathbb{N}$ is defined as \[
-\text{NegBinomial2}(n \, | \, \mu, \phi)  = \binom{n + \phi - 1}{y} \,
-\left( \frac{\mu}{\mu+\phi} \right)^{\!y} \, \left(
+\text{NegBinomial2}(n \, | \, \mu, \phi)  = \binom{n + \phi - 1}{n} \,
+\left( \frac{\mu}{\mu+\phi} \right)^{\!n} \, \left(
 \frac{\phi}{\mu+\phi} \right)^{\!\phi} \!. \]
 
 The mean and variance of a random variable $n \sim


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Density of NegBinomial2 was written with `y` as the argument in earlier versions, and thereafter `y` has been replaced with `n`. However, it still contains `y` in two places, and `n` elsewhere, being inconsistent. This unifies notation to use only `n`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Me



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
