### PR TITLE
Fix return value of integrate_1d to be real

### DIFF
--- a/src/functions-reference/higher-order_functions.Rmd
+++ b/src/functions-reference/higher-order_functions.Rmd
@@ -329,16 +329,16 @@ integrator separates parameter values, `theta`, from data values, `x_r`.
 
 ### Call to the 1D Integrator
 
-<!-- vector; integrate_1d; (function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i); -->
-\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, real[] theta, real[] x\_r, int[] x\_i): vector}|hyperpage}
+<!-- real; integrate_1d; (function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i); -->
+\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, real[] theta, real[] x\_r, int[] x\_i): real}|hyperpage}
 
-`vector` **`integrate_1d`** `(function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i)`<br>\newline
+`real` **`integrate_1d`** `(function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i)`<br>\newline
 Integrates the integrand from a to b.
 
-<!-- vector; integrate_1d; (function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i), real relative_tolerance); -->
-\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, real[] theta, real[] x\_r, int[] x\_i, real relative\_tolerance): vector}|hyperpage}
+<!-- real; integrate_1d; (function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i), real relative_tolerance); -->
+\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, real[] theta, real[] x\_r, int[] x\_i, real relative\_tolerance): real}|hyperpage}
 
-`vector` **`integrate_1d`** `(function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i, real relative_tolerance)`<br>\newline
+`real` **`integrate_1d`** `(function integrand, real a, real b, real[] theta, real[] x_r, int[] x_i, real relative_tolerance)`<br>\newline
 Integrates the integrand from a to b with the given relative tolerance.
 
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
`integrate_1d` doesn't return a vector but a real.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
