### PR TITLE
Rmd italics & build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ GitHub (re)builds and (re)deploys the website.
 
 ## Generating the static site
 
-1. Install R packages:  bookdown
+1. Install R packages:  bookdown, arm
 
 2. Install on OS and ensure on PATH: pandoc, pandoc-citeproc, pdflatex
 

--- a/src/stan-users-guide/regression.Rmd
+++ b/src/stan-users-guide/regression.Rmd
@@ -278,7 +278,7 @@ regression models may be used.  These generalized linear models vary
 only in the link function they use to map linear predictions in
 $(-\infty,\infty)$ to probability values in $(0,1)$.  Their respective
 link functions, the logistic function and the standard normal cumulative distribution
-function, are both sigmoid functions (i.e., they are both \textit{S}-shaped).
+function, are both sigmoid functions (i.e., they are both *S*-shaped).
 
 A logistic regression model with one predictor and an intercept is coded as
 follows.


### PR DESCRIPTION
#### Submission Checklist

- [ x] Builds locally 
- [ x] Declare copyright holder and open-source license: see below

#### Summary
I noticed that using `\textit{S}-shaped`, as we do in `regression.Rmd`, does not work when generating `html`. I've changed it to `*S*-shaped`.

Additionally, when trying to build the `html` version of the User's Guide it immediately bailed with:
> Quitting from lines 19-73 (_main.Rmd) 
> Error in library(arm) : there is no package called 'arm'

I've changed the `README` to reflect the need to install `arm`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Richard Torkar, richard.torkar@gmail.com

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
