### PR TITLE
Add pedantic mode doc to reference manual

### DIFF
--- a/src/reference-manual/_bookdown.yml
+++ b/src/reference-manual/_bookdown.yml
@@ -26,6 +26,7 @@ rmd_files: [
  "optimization.Rmd",
  "variational.Rmd",
  "diagnostics.Rmd",
+ "pedantic-mode.Rmd", 
 
  "usage.Rmd",
  "reproducibility.Rmd", 

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -1,10 +1,10 @@
 
 
-# Pedantic Mode
+# Pedantic mode
 
-Pedantic Mode is a compilation option built into Stanc3 that warns you about potential issues in your Stan program.
+Pedantic mode is a compilation option built into Stanc3 that warns you about potential issues in your Stan program.
 
-For example, if you compile the following program with Pedantic Mode:
+For example, consider the following program.
 
     data {
       int N;
@@ -18,7 +18,7 @@ For example, if you compile the following program with Pedantic Mode:
       x ~ normal(mu, sigma);
     }
 
-The compiler will print the following to stderr:
+When pedantic mode is turned on, the compiler will produce the following warnings.
 
     Warning:
       The parameter sigma has no priors.
@@ -28,7 +28,7 @@ The compiler will print the following to stderr:
       A normal distribution is given parameter sigma as a scale parameter
       (argument 2), but sigma was not constrained to be strictly positive.
 
-Here are the kinds of issues that Pedantic Mode will find (which are described in more detail in following sections):
+Here are the kinds of issues that pedantic mode will find (which are described in more detail in following sections):
 
 -   *Distribution usages issues.* Distribution arguments don't match the distribution specification, or some specific distribution is used in an inadvisable way.
 -   *Unused parameter.* A parameter is defined but doesn't contribute to target.
@@ -39,14 +39,14 @@ Here are the kinds of issues that Pedantic Mode will find (which are described i
 -   *Variable is used before assignment.* A variable is used before being assigned a value.
 -   *Strict or nonsensical parameter bounds.* A parameter is given questionable bounds.
 
-Some important limitations of Pedantic Mode are listed at the end of this chapter.
+Some important limitations of pedantic mode are listed at the end of this chapter.
 
 
 ## Distribution argument and variate constraint issues
 
 When an argument to a built-in distribution certainly does not match that distribution's specification in the [Stan Functions Reference](https://mc-stan.org/docs/functions-reference/index.html), a warning is thrown. This primarily checks if any distribution argument's bounds at declaration, compile-time value, or subtype at declaration (e.g. `simplex`) is incompatible with the domain of the distribution.
 
-For example:
+For example, consider the following program.
 
     parameters {
       real unb_p;
@@ -59,7 +59,7 @@ For example:
 
 The parameter of `poisson` should be strictly positive, but `unb_p` is not constrained to be positive.
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning at 'ex-dist-args.stan', line 6, column 14 to column 19:
       A poisson distribution is given parameter unb_p as a rate parameter
@@ -76,7 +76,7 @@ Pedantic mode checks for some specific uses of distributions that may indicate a
 Any use of uniform distribution generates a warning, except when the variate parameter's declared `upper` and `lower` bounds exactly match the uniform distribution bounds.
 In general, assigning a parameter a uniform distribution can create non-differentiable boundary conditions and is not recommended.
 
-For example:
+For example, consider the following program.
 
     parameters {
       real a;
@@ -89,7 +89,7 @@ For example:
 
 `a` is assigned a uniform distribution that doesn't match its constraints.
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning at 'uniform-warn.stan', line 6, column 2 to column 20:
       Parameter a is given a uniform distribution. The uniform distribution is
@@ -119,7 +119,7 @@ See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for deta
 A warning is generated when a parameter is declared but does not have any effect on the program.
 This is determined by checking whether the value of the `target` variable depends in any way on each of the parameters.
 
-For example:
+For example, consider the following program.
 
     parameters {
       real a;
@@ -131,7 +131,7 @@ For example:
 
 `a` participates in the density function but `b` does not.
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning:
       The parameter b was declared but was not used in the density calculation.
@@ -142,7 +142,7 @@ This program results in the following warning:
 When numbers with magnitude less than 0.1 or greater than 10 are used as arguments to a distribution, it indicates that some parameter is not scaled to unit value, so a warning is thrown.
 See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outputs.html> for a discussion of scaling parameters.
 
-For example:
+For example, consider the following program.
 
     parameters {
       real x;
@@ -155,7 +155,7 @@ For example:
 
 The constants `-100` and `100` suggest that `x` is not unit scaled.
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning at 'constants-warn.stan', line 6, column 14 to column 17:
       Argument -100 suggests there may be parameters that are not unit scale;
@@ -171,7 +171,7 @@ Control flow statements, such as `if`, `for` and `while`, should not depend on p
 This is likely to introduce a discontinuity into the density function.
 Pedantic mode generates a warning when any branching condition may depend on a parameter value.
 
-For example:
+For example, consider the following program.
 
     parameters {
       real a;
@@ -198,7 +198,7 @@ For example:
 
 The `if` and `for` statements are control flow that depend (indirectly) on the value of the parameter `m`.
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning at 'param-dep-cf-warn.stan', line 11, column 2 to line 16, column 3:
       A control flow statement depends on parameter(s): a.
@@ -213,7 +213,7 @@ This pattern is not inherently an issue, but it is unusual and may indicate a mi
 
 Pedantic mode only searches for repeated statements, it will not for example generate a warning when a ~ statement is executed repeatedly inside of a loop.
 
-For example:
+For example, consider the following program.
 
     data {
       real x;
@@ -229,7 +229,7 @@ For example:
       b ~ normal(1, 1);
     }
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning at 'multi-twiddle.stan', line 9, column 2 to column 19:
       The parameter a is on the left-hand side of more than one twiddle
@@ -244,7 +244,7 @@ This analysis depends on a [*factor graph*](https://en.wikipedia.org/wiki/Factor
 
 One limitation of this approach is that the compiler cannot distinguish between *modeled* `data` variables and other convenient uses of `data` variables such as data sizes or hyperparameters. This warning assumes that all data variables (except for `int` variables) are modeled data, which may cause extra warnings.
 
-For example:
+For example, consider the following program.
 
     data {
       real x;
@@ -273,7 +273,7 @@ For example:
 
 One prior is found for `a` and for `b`, while `c` only has a factor that touches a `data` variable and `d` has multiple priors.
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning:
       The parameter c has no priors.
@@ -285,7 +285,7 @@ This program results in the following warning:
 
 A warning is generated when any variable is used before it has been assigned a value.
 
-For example:
+For example, consider the following program.
 
     transformed data {
       real x;
@@ -298,7 +298,7 @@ For example:
 
 Since `x` is only assigned in one of the branches of the `if` statement, it might get to `print(x)` without having been assigned to. 
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning at 'uninit-warn.stan', line 7, column 8 to column 9:
       The variable x may not have been assigned a value before its use.
@@ -311,7 +311,7 @@ A warning is generated for all parameters declared with the bounds `<lower=.., u
 
 In addition, a warning is generated when a parameter bound is found to have `lower >= upper`.
 
-For example:
+For example, consider the following program.
 
     parameters {
       real<lower=0, upper=1> a;
@@ -322,7 +322,7 @@ For example:
       c ~ normal(b, a);
     }
 
-This program results in the following warning:
+Pedantic mode produces the following warning.
 
     Warning:
       Your Stan program has a parameter c with a lower and upper bound in its
@@ -336,7 +336,7 @@ This program results in the following warning:
       unconstrained and give it a normal(0.5,0.5) prior distribution.
 
 
-## Pedantic Mode limitations
+## Pedantic mode limitations
 
 
 #### Constant values are sometimes uncomputable

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -47,7 +47,6 @@ Some important limitations of Pedantic Mode are listed at the end of this sectio
 
 ### Argument and variate constraint issues
 
-<a id="orgd9214d2"></a>
 When an argument to a built-in distribution certainly does not match that distribution's specification in the [Stan Functions Reference](https://mc-stan.org/docs/functions-reference/index.html), a warning is thrown. This primarily checks if any distribution argument's bounds at declaration, compile-time value, or subtype at declaration (e.g. `simplex`) is incompatible with the domain of the distribution.
 
 For example, in the following program:
@@ -71,7 +70,6 @@ This produces the following warning:
 
 ### Special-case distribution issues
 
-<a id="org5f3c7e0"></a>
 Pedantic mode checks for some specific uses of distributions that may indicate a statistical mistake:
 
 
@@ -95,21 +93,18 @@ See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for deta
 
 ## Unused parameters
 
-<a id="org17b43e7"></a>
 A warning is generated when a parameter is declared but does not have any effect on the program.
 This is determined by checking whether the value of the `target` variable depends in any way on each of the parameters.
 
 
 ## Large or small constants in a distribution
 
-<a id="orgb4789bb"></a>
 When numbers with magnitude less than 0.1 or greater than 10 are used as arguments to a distribution, it indicates that some parameter is not scaled to unit value, so a warning is thrown.
 See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outputs.html> for a discussion of scaling parameters.
 
 
 ## Control flow depends on a parameter
 
-<a id="org76ab7e5"></a>
 Control flow statements, such as `if`, `for` and `while`, should not depend on the value of the parameters to determine their branching conditions.
 Otherwise, the program may branch differently between iterations, which is likely to introduce discontinuity into the density function.
 Pedantic mode generates a warning when any branching condition may depend on a parameter value.
@@ -117,7 +112,6 @@ Pedantic mode generates a warning when any branching condition may depend on a p
 
 ## Parameters with multiple twiddles
 
-<a id="orgb60d090"></a>
 A warning is generated when a parameter is found on the left-hand side of more than one ~ statements (or an equivalent `target +=` conditional density statement).
 This pattern is not inherently an issue, but it is unusual and may indicate a mistake.
 
@@ -126,7 +120,6 @@ Pedantic mode only searches for repeated statements, it will not for example gen
 
 ## Parameters with zero or multiple priors
 
-<a id="orgc034d9e"></a>
 A warning is generated when a parameter appears to have greater than or less than one prior distribution factor.
 
 This analysis depends on a [*factor graph*](https://en.wikipedia.org/wiki/Factor_graph) representation of a Stan program. A factor F that depends on a parameter P is called a *prior factor for P* if there is no path in the factor graph from F to any data variable except through P.
@@ -134,14 +127,12 @@ This analysis depends on a [*factor graph*](https://en.wikipedia.org/wiki/Factor
 
 ## Variables used before assignment
 
-<a id="org565cee9"></a>
 A warning is generated when any variable is used before it has been assigned a value.
 This warning is also available as a standalone option to Stanc3, with the flag: `--warn-uninitialized`.
 
 
 ## Strict or nonsensical parameter bounds
 
-<a id="org2a84a6b"></a>
 Parameters that are have strict `upper` and `lower` bounds can cause unmanageably large gradients in a density function, and may only be justified in a few cased.
 A warning is generated for all parameters declared with the bounds `<lower=.., upper=..>` except for `<lower=0, upper=1>` or `<lower=-1, upper=1>`.
 
@@ -149,8 +140,6 @@ In addition, a warning is generated when a parameter bound is found to have `upp
 
 
 ## Pedantic Mode limitations
-
-<a id="org9638524"></a>
 
 
 #### Constant values are sometimes uncomputable

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -1,32 +1,34 @@
-
-
 # Pedantic mode
 
 Pedantic mode is a compilation option built into Stanc3 that warns you about potential issues in your Stan program.
 
 For example, consider the following program.
 
-    data {
-      int N;
-      real x[N];
-    }
-    parameters {
-      real sigma;
-    }
-    model {
-      real mu;
-      x ~ normal(mu, sigma);
-    }
+```
+data {
+  int N;
+  real x[N];
+}
+parameters {
+  real sigma;
+}
+model {
+  real mu;
+  x ~ normal(mu, sigma);
+}
+```
 
 When pedantic mode is turned on, the compiler will produce the following warnings.
 
-    Warning:
-      The parameter sigma has no priors.
-    Warning at 'ped-mode-ex1.stan', line 10, column 14 to column 16:
-      The variable mu may not have been assigned a value before its use.
-    Warning at 'ped-mode-ex1.stan', line 10, column 18 to column 23:
-      A normal distribution is given parameter sigma as a scale parameter
-      (argument 2), but sigma was not constrained to be strictly positive.
+```
+Warning:
+  The parameter sigma has no priors.
+Warning at 'ped-mode-ex1.stan', line 10, column 14 to column 16:
+  The variable mu may not have been assigned a value before its use.
+Warning at 'ped-mode-ex1.stan', line 10, column 18 to column 23:
+  A normal distribution is given parameter sigma as a scale parameter
+  (argument 2), but sigma was not constrained to be strictly positive.
+```
 
 Here are the kinds of issues that pedantic mode will find (which are described in more detail in following sections):
 
@@ -48,22 +50,26 @@ When an argument to a built-in distribution certainly does not match that distri
 
 For example, consider the following program.
 
-    parameters {
-      real unb_p;
-      real<lower=0> pos_p;
-    }
-    model {
-      1 ~ poisson(unb_p);
-      1 ~ poisson(pos_p);
-    }
+```
+parameters {
+  real unb_p;
+  real<lower=0> pos_p;
+}
+model {
+  1 ~ poisson(unb_p);
+  1 ~ poisson(pos_p);
+}
+```
 
 The parameter of `poisson` should be strictly positive, but `unb_p` is not constrained to be positive.
 
 Pedantic mode produces the following warning.
 
-    Warning at 'ex-dist-args.stan', line 6, column 14 to column 19:
-      A poisson distribution is given parameter unb_p as a rate parameter
-      (argument 1), but unb_p was not constrained to be strictly positive.
+```
+Warning at 'ex-dist-args.stan', line 6, column 14 to column 19:
+  A poisson distribution is given parameter unb_p as a rate parameter
+  (argument 1), but unb_p was not constrained to be strictly positive.
+```
 
 
 ## Special-case distribution issues
@@ -73,167 +79,179 @@ Pedantic mode checks for some specific uses of distributions that may indicate a
 
 ### Uniform distributions
 
-Any use of uniform distribution generates a warning, except when the variate parameter's declared `upper` and `lower` bounds exactly match the uniform distribution bounds.
-In general, assigning a parameter a uniform distribution can create non-differentiable boundary conditions and is not recommended.
+Any use of uniform distribution generates a warning, except when the variate parameter's declared `upper` and `lower` bounds exactly match the uniform distribution bounds. In general, assigning a parameter a uniform distribution can create non-differentiable boundary conditions and is not recommended.
 
 For example, consider the following program.
 
-    parameters {
-      real a;
-      real<lower=0, upper=1> b;
-    }
-    model {
-      a ~ uniform(0, 1);
-      b ~ uniform(0, 1);
-    }
+```
+parameters {
+  real a;
+  real<lower=0, upper=1> b;
+}
+model {
+  a ~ uniform(0, 1);
+  b ~ uniform(0, 1);
+}
+```
 
 `a` is assigned a uniform distribution that doesn't match its constraints.
 
 Pedantic mode produces the following warning.
 
-    Warning at 'uniform-warn.stan', line 6, column 2 to column 20:
-      Parameter a is given a uniform distribution. The uniform distribution is
-      not recommended, for two reasons: (a) Except when there are logical or
-      physical constraints, it is very unusual for you to be sure that a
-      parameter will fall inside a specified range, and (b) The infinite gradient
-      induced by a uniform density can cause difficulties for Stan's sampling
-      algorithm. As a consequence, we recommend soft constraints rather than hard
-      constraints; for example, instead of giving an elasticity parameter a
-      uniform(0,1) distribution, try normal(0.5,0.5).
+```
+Warning at 'uniform-warn.stan', line 6, column 2 to column 20:
+  Parameter a is given a uniform distribution. The uniform distribution is
+  not recommended, for two reasons: (a) Except when there are logical or
+  physical constraints, it is very unusual for you to be sure that a
+  parameter will fall inside a specified range, and (b) The infinite gradient
+  induced by a uniform density can cause difficulties for Stan's sampling
+  algorithm. As a consequence, we recommend soft constraints rather than hard
+  constraints; for example, instead of giving an elasticity parameter a
+  uniform(0,1) distribution, try normal(0.5,0.5).
+```
 
 
 ### (Inverse-) Gamma distributions
 
-Gamma distributions are sometimes used as an attempt to assign an improper prior to a parameter.
-Pedantic mode gives a warning when the Gamma arguments indicate that this may be the case.
+Gamma distributions are sometimes used as an attempt to assign an improper prior to a parameter. Pedantic mode gives a warning when the Gamma arguments indicate that this may be the case.
 
 
 ### lkj\_corr distribution
 
-Any use of the `lkj_corr` distribution generates a warning that suggests using the Cholesky variant instead.
-See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for details.
+Any use of the `lkj_corr` distribution generates a warning that suggests using the Cholesky variant instead. See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for details.
 
 
 ## Unused parameters
 
-A warning is generated when a parameter is declared but does not have any effect on the program.
-This is determined by checking whether the value of the `target` variable depends in any way on each of the parameters.
+A warning is generated when a parameter is declared but does not have any effect on the program. This is determined by checking whether the value of the `target` variable depends in any way on each of the parameters.
 
 For example, consider the following program.
 
-    parameters {
-      real a;
-      real b;
-    }
-    model {
-      a ~ normal(1, 1);
-    }
+```
+parameters {
+  real a;
+  real b;
+}
+model {
+  a ~ normal(1, 1);
+}
+```
 
 `a` participates in the density function but `b` does not.
 
 Pedantic mode produces the following warning.
 
-    Warning:
-      The parameter b was declared but was not used in the density calculation.
+```
+Warning:
+  The parameter b was declared but was not used in the density calculation.
+```
 
 
 ## Large or small constants in a distribution
 
-When numbers with magnitude less than 0.1 or greater than 10 are used as arguments to a distribution, it indicates that some parameter is not scaled to unit value, so a warning is thrown.
-See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outputs.html> for a discussion of scaling parameters.
+When numbers with magnitude less than 0.1 or greater than 10 are used as arguments to a distribution, it indicates that some parameter is not scaled to unit value, so a warning is thrown. See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outputs.html> for a discussion of scaling parameters.
 
 For example, consider the following program.
 
-    parameters {
-      real x;
-      real y;
-    }
-    model {
-      x ~ normal(-100, 100);
-      y ~ normal(0, 1);
-    }
+```
+parameters {
+  real x;
+  real y;
+}
+model {
+  x ~ normal(-100, 100);
+  y ~ normal(0, 1);
+}
+```
 
 The constants `-100` and `100` suggest that `x` is not unit scaled.
 
 Pedantic mode produces the following warning.
 
-    Warning at 'constants-warn.stan', line 6, column 14 to column 17:
-      Argument -100 suggests there may be parameters that are not unit scale;
-      consider rescaling with a multiplier (see manual section 22.12).
-    Warning at 'constants-warn.stan', line 6, column 19 to column 22:
-      Argument 100 suggests there may be parameters that are not unit scale;
-      consider rescaling with a multiplier (see manual section 22.12).
+```
+Warning at 'constants-warn.stan', line 6, column 14 to column 17:
+  Argument -100 suggests there may be parameters that are not unit scale;
+  consider rescaling with a multiplier (see manual section 22.12).
+Warning at 'constants-warn.stan', line 6, column 19 to column 22:
+  Argument 100 suggests there may be parameters that are not unit scale;
+  consider rescaling with a multiplier (see manual section 22.12).
+```
 
 
 ## Control flow depends on a parameter
 
-Control flow statements, such as `if`, `for` and `while`, should not depend on parameters or functions of parameters to determine their branching conditions.
-This is likely to introduce a discontinuity into the density function.
-Pedantic mode generates a warning when any branching condition may depend on a parameter value.
+Control flow statements, such as `if`, `for` and `while`, should not depend on parameters or functions of parameters to determine their branching conditions. This is likely to introduce a discontinuity into the density function. Pedantic mode generates a warning when any branching condition may depend on a parameter value.
 
 For example, consider the following program.
 
-    parameters {
-      real a;
-    }
-    model {
-      // x depends on parameter a
-      real x = a * a;
-    
-      int m;
-    
-      // the if-then-else depends on x which depends on a
-      if(x > 0) {
-        //now m depends on x which depends on a
-        m = 1;
-      } else {
-        m = 2;
-      }
-    
-      // for loop depends on m -> x -> a
-      for (i in 0:m) {
-        a ~ normal(i, 1);
-      }
-    }
+```
+parameters {
+  real a;
+}
+model {
+  // x depends on parameter a
+  real x = a * a;
+
+  int m;
+
+  // the if-then-else depends on x which depends on a
+  if(x > 0) {
+    //now m depends on x which depends on a
+    m = 1;
+  } else {
+    m = 2;
+  }
+
+  // for loop depends on m -> x -> a
+  for (i in 0:m) {
+    a ~ normal(i, 1);
+  }
+}
+```
 
 The `if` and `for` statements are control flow that depend (indirectly) on the value of the parameter `m`.
 
 Pedantic mode produces the following warning.
 
-    Warning at 'param-dep-cf-warn.stan', line 11, column 2 to line 16, column 3:
-      A control flow statement depends on parameter(s): a.
-    Warning at 'param-dep-cf-warn.stan', line 19, column 2 to line 21, column 3:
-      A control flow statement depends on parameter(s): a.
+```
+Warning at 'param-dep-cf-warn.stan', line 11, column 2 to line 16, column 3:
+  A control flow statement depends on parameter(s): a.
+Warning at 'param-dep-cf-warn.stan', line 19, column 2 to line 21, column 3:
+  A control flow statement depends on parameter(s): a.
+```
 
 
 ## Parameters with multiple twiddles
 
-A warning is generated when a parameter is found on the left-hand side of more than one ~ statements (or an equivalent `target +=` conditional density statement).
-This pattern is not inherently an issue, but it is unusual and may indicate a mistake.
+A warning is generated when a parameter is found on the left-hand side of more than one ~ statements (or an equivalent `target +=` conditional density statement). This pattern is not inherently an issue, but it is unusual and may indicate a mistake.
 
 Pedantic mode only searches for repeated statements, it will not for example generate a warning when a ~ statement is executed repeatedly inside of a loop.
 
 For example, consider the following program.
 
-    data {
-      real x;
-    }
-    parameters {
-      real a;
-      real b;
-    }
-    model {
-      a ~ normal(0, 1);
-      a ~ normal(x, 1);
-    
-      b ~ normal(1, 1);
-    }
+```
+data {
+  real x;
+}
+parameters {
+  real a;
+  real b;
+}
+model {
+  a ~ normal(0, 1);
+  a ~ normal(x, 1);
+
+  b ~ normal(1, 1);
+}
+```
 
 Pedantic mode produces the following warning.
 
-    Warning at 'multi-twiddle.stan', line 9, column 2 to column 19:
-      The parameter a is on the left-hand side of more than one twiddle
-      statement.
+```
+Warning at 'multi-twiddle.stan', line 9, column 2 to column 19:
+  The parameter a is on the left-hand side of more than one twiddle
+  statement.
+```
 
 
 ## Parameters with zero or multiple priors
@@ -246,39 +264,43 @@ One limitation of this approach is that the compiler cannot distinguish between 
 
 For example, consider the following program.
 
-    data {
-      real x;
-    }
-    parameters {
-      real a;
-      real b;
-      real c;
-      real d;
-    }
-    model
-    {
-      a ~ normal(0, 1); // this is a prior
-      x ~ normal(a, 1); // this is not a prior, since data is involved
-    
-      b ~ normal(x, 1); // this is also not a prior, since data is involved
-    
-      // this is not a prior for c, since data is involved through b
-      // but it is a prior for b, since the data is only involved through b
-      c ~ normal(b, 1);
-    
-      //these are multiple priors:
-      d ~ normal(0, 1);
-      1 ~ normal(d, 1);
-    }
+```
+data {
+  real x;
+}
+parameters {
+  real a;
+  real b;
+  real c;
+  real d;
+}
+model
+{
+  a ~ normal(0, 1); // this is a prior
+  x ~ normal(a, 1); // this is not a prior, since data is involved
+
+  b ~ normal(x, 1); // this is also not a prior, since data is involved
+
+  // this is not a prior for c, since data is involved through b
+  // but it is a prior for b, since the data is only involved through b
+  c ~ normal(b, 1);
+
+  //these are multiple priors:
+  d ~ normal(0, 1);
+  1 ~ normal(d, 1);
+}
+```
 
 One prior is found for `a` and for `b`, while `c` only has a factor that touches a `data` variable and `d` has multiple priors.
 
 Pedantic mode produces the following warning.
 
-    Warning:
-      The parameter c has no priors.
-    Warning:
-      The parameter d has 2 priors.
+```
+Warning:
+  The parameter c has no priors.
+Warning:
+  The parameter d has 2 priors.
+```
 
 
 ## Variables used before assignment
@@ -287,53 +309,60 @@ A warning is generated when any variable is used before it has been assigned a v
 
 For example, consider the following program.
 
-    transformed data {
-      real x;
-      if (1 > 2)
-        x = 1;
-      else
-        print("oops");
-      print(x);
-    }
+```
+transformed data {
+  real x;
+  if (1 > 2)
+    x = 1;
+  else
+    print("oops");
+  print(x);
+}
+```
 
-Since `x` is only assigned in one of the branches of the `if` statement, it might get to `print(x)` without having been assigned to. 
+Since `x` is only assigned in one of the branches of the `if` statement, it might get to `print(x)` without having been assigned to.
 
 Pedantic mode produces the following warning.
 
-    Warning at 'uninit-warn.stan', line 7, column 8 to column 9:
-      The variable x may not have been assigned a value before its use.
+```
+Warning at 'uninit-warn.stan', line 7, column 8 to column 9:
+  The variable x may not have been assigned a value before its use.
+```
 
 
 ## Strict or nonsensical parameter bounds
 
-Except when there are logical or physical constraints, it is very unusual for you to be sure that a parameter will fall inside a specified range.
-A warning is generated for all parameters declared with the bounds `<lower=.., upper=..>` except for `<lower=0, upper=1>` or `<lower=-1, upper=1>`.
+Except when there are logical or physical constraints, it is very unusual for you to be sure that a parameter will fall inside a specified range. A warning is generated for all parameters declared with the bounds `<lower=.., upper=..>` except for `<lower=0, upper=1>` or `<lower=-1, upper=1>`.
 
 In addition, a warning is generated when a parameter bound is found to have `lower >= upper`.
 
 For example, consider the following program.
 
-    parameters {
-      real<lower=0, upper=1> a;
-      real<lower=-1, upper=1> b;
-      real<lower=-2, upper=1012> c;
-    }
-    model {
-      c ~ normal(b, a);
-    }
+```
+parameters {
+  real<lower=0, upper=1> a;
+  real<lower=-1, upper=1> b;
+  real<lower=-2, upper=1012> c;
+}
+model {
+  c ~ normal(b, a);
+}
+```
 
 Pedantic mode produces the following warning.
 
-    Warning:
-      Your Stan program has a parameter c with a lower and upper bound in its
-      declaration. These hard constraints are not recommended, for two reasons:
-      (a) Except when there are logical or physical constraints, it is very
-      unusual for you to be sure that a parameter will fall inside a specified
-      range, and (b) The infinite gradient induced by a hard constraint can cause
-      difficulties for Stan's sampling algorithm. As a consequence, we recommend
-      soft constraints rather than hard constraints; for example, instead of
-      constraining an elasticity parameter to fall between 0, and 1, leave it
-      unconstrained and give it a normal(0.5,0.5) prior distribution.
+```
+Warning:
+  Your Stan program has a parameter c with a lower and upper bound in its
+  declaration. These hard constraints are not recommended, for two reasons:
+  (a) Except when there are logical or physical constraints, it is very
+  unusual for you to be sure that a parameter will fall inside a specified
+  range, and (b) The infinite gradient induced by a hard constraint can cause
+  difficulties for Stan's sampling algorithm. As a consequence, we recommend
+  soft constraints rather than hard constraints; for example, instead of
+  constraining an elasticity parameter to fall between 0, and 1, leave it
+  unconstrained and give it a normal(0.5,0.5) prior distribution.
+```
 
 
 ## Pedantic mode limitations
@@ -341,15 +370,12 @@ Pedantic mode produces the following warning.
 
 #### Constant values are sometimes uncomputable
 
-Pedantic mode attempts to evaluate expressions down to literal values so that they can be used to generate warnings.
-For example, in the code `normal(x, 1 - 2)`, the expression `1 - 2` will be evaluated to `-1`, which is not a valid variance argument so a warning is generated.
-However, this strategy is limited; it is often impossible to fully evaluate expressions in finite time.
+Pedantic mode attempts to evaluate expressions down to literal values so that they can be used to generate warnings. For example, in the code `normal(x, 1 - 2)`, the expression `1 - 2` will be evaluated to `-1`, which is not a valid variance argument so a warning is generated. However, this strategy is limited; it is often impossible to fully evaluate expressions in finite time.
 
 
 #### Container types
 
-Currently, indexed variables are not handled intelligently, so they are treated as monolithic variables.
-Each analysis treats indexed variables conservatively (erring toward generating fewer warnings).
+Currently, indexed variables are not handled intelligently, so they are treated as monolithic variables. Each analysis treats indexed variables conservatively (erring toward generating fewer warnings).
 
 
 #### Data variables
@@ -360,4 +386,3 @@ The declaration information for `data` variables is currently not considered, so
 #### Control flow dependent on parameters in nested functions
 
 If a parameter is passed as an argument to a user-defined function within another user-defined function, and then some control flow depends on that argument, the appropriate warning will not be thrown.
-

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -46,7 +46,7 @@ Some important limitations of Pedantic Mode are listed at the end of this chapte
 
 When an argument to a built-in distribution certainly does not match that distribution's specification in the [Stan Functions Reference](https://mc-stan.org/docs/functions-reference/index.html), a warning is thrown. This primarily checks if any distribution argument's bounds at declaration, compile-time value, or subtype at declaration (e.g. `simplex`) is incompatible with the domain of the distribution.
 
-For example, in the following program:
+For example:
 
     parameters {
       real unb_p;
@@ -58,7 +58,8 @@ For example, in the following program:
     }
 
 The parameter of `poisson` should be strictly positive, but `unb_p` is not constrained to be positive.
-This produces the following warning:
+
+This program results in the following warning:
 
     Warning at 'ex-dist-args.stan', line 6, column 14 to column 19:
       A poisson distribution is given parameter unb_p as a rate parameter
@@ -75,7 +76,7 @@ Pedantic mode checks for some specific uses of distributions that may indicate a
 Any use of uniform distribution generates a warning, except when the variate parameter's declared `upper` and `lower` bounds exactly match the uniform distribution bounds.
 In general, assigning a parameter a uniform distribution can create non-differentiable boundary conditions and is not recommended.
 
-For example, in the following program:
+For example:
 
     parameters {
       real a;
@@ -86,7 +87,9 @@ For example, in the following program:
       b ~ uniform(0, 1);
     }
 
-This produces the following warning:
+`a` is assigned a uniform distribution that doesn't match its constraints.
+
+This program results in the following warning:
 
     Warning at 'uniform-warn.stan', line 6, column 2 to column 20:
       Parameter a is given a uniform distribution. The uniform distribution is
@@ -116,7 +119,7 @@ See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for deta
 A warning is generated when a parameter is declared but does not have any effect on the program.
 This is determined by checking whether the value of the `target` variable depends in any way on each of the parameters.
 
-For example, in the following program:
+For example:
 
     parameters {
       real a;
@@ -126,7 +129,9 @@ For example, in the following program:
       a ~ normal(1, 1);
     }
 
-This produces the following warning:
+`a` participates in the density function but `b` does not.
+
+This program results in the following warning:
 
     Warning:
       The parameter b was declared but was not used in the density calculation.
@@ -137,18 +142,20 @@ This produces the following warning:
 When numbers with magnitude less than 0.1 or greater than 10 are used as arguments to a distribution, it indicates that some parameter is not scaled to unit value, so a warning is thrown.
 See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outputs.html> for a discussion of scaling parameters.
 
-For example, in the following program:
+For example:
 
     parameters {
       real x;
-      real<offset=-100, multiplier=100> y;
+      real y;
     }
     model {
       x ~ normal(-100, 100);
       y ~ normal(0, 1);
     }
 
-This produces the following warning:
+The constants `-100` and `100` suggest that `x` is not unit scaled.
+
+This program results in the following warning:
 
     Warning at 'constants-warn.stan', line 6, column 14 to column 17:
       Argument -100 suggests there may be parameters that are not unit scale;
@@ -160,11 +167,11 @@ This produces the following warning:
 
 ## Control flow depends on a parameter
 
-Control flow statements, such as `if`, `for` and `while`, should not depend on the value of the parameters to determine their branching conditions.
-This is likely to introduce discontinuity into the density function.
+Control flow statements, such as `if`, `for` and `while`, should not depend on parameters or functions of parameters to determine their branching conditions.
+This is likely to introduce a discontinuity into the density function.
 Pedantic mode generates a warning when any branching condition may depend on a parameter value.
 
-For example, in the following program:
+For example:
 
     parameters {
       real a;
@@ -189,7 +196,9 @@ For example, in the following program:
       }
     }
 
-This produces the following warning:
+The `if` and `for` statements are control flow that depend (indirectly) on the value of the parameter `m`.
+
+This program results in the following warning:
 
     Warning at 'param-dep-cf-warn.stan', line 11, column 2 to line 16, column 3:
       A control flow statement depends on parameter(s): a.
@@ -204,7 +213,7 @@ This pattern is not inherently an issue, but it is unusual and may indicate a mi
 
 Pedantic mode only searches for repeated statements, it will not for example generate a warning when a ~ statement is executed repeatedly inside of a loop.
 
-For example, in the following program:
+For example:
 
     data {
       real x;
@@ -220,7 +229,7 @@ For example, in the following program:
       b ~ normal(1, 1);
     }
 
-This produces the following warning:
+This program results in the following warning:
 
     Warning at 'multi-twiddle.stan', line 9, column 2 to column 19:
       The parameter a is on the left-hand side of more than one twiddle
@@ -233,7 +242,9 @@ A warning is generated when a parameter appears to have greater than or less tha
 
 This analysis depends on a [*factor graph*](https://en.wikipedia.org/wiki/Factor_graph) representation of a Stan program. A factor F that depends on a parameter P is called a *prior factor for P* if there is no path in the factor graph from F to any data variable except through P.
 
-For example, in the following program:
+One limitation of this approach is that the compiler cannot distinguish between *modeled* `data` variables and other convenient uses of `data` variables such as data sizes or hyperparameters. This warning assumes that all data variables (except for `int` variables) are modeled data, which may cause extra warnings.
+
+For example:
 
     data {
       real x;
@@ -260,7 +271,9 @@ For example, in the following program:
       1 ~ normal(d, 1);
     }
 
-This produces the following warning:
+One prior is found for `a` and for `b`, while `c` only has a factor that touches a `data` variable and `d` has multiple priors.
+
+This program results in the following warning:
 
     Warning:
       The parameter c has no priors.
@@ -272,18 +285,20 @@ This produces the following warning:
 
 A warning is generated when any variable is used before it has been assigned a value.
 
-For example, in the following program:
+For example:
 
     transformed data {
       real x;
-      if (2 > 1)
+      if (1 > 2)
         x = 1;
       else
         print("oops");
       print(x);
     }
 
-This produces the following warning:
+Since `x` is only assigned in one of the branches of the `if` statement, it might get to `print(x)` without having been assigned to. 
+
+This program results in the following warning:
 
     Warning at 'uninit-warn.stan', line 7, column 8 to column 9:
       The variable x may not have been assigned a value before its use.
@@ -296,15 +311,18 @@ A warning is generated for all parameters declared with the bounds `<lower=.., u
 
 In addition, a warning is generated when a parameter bound is found to have `lower >= upper`.
 
-For example, in the following program:
+For example:
 
     parameters {
       real<lower=0, upper=1> a;
       real<lower=-1, upper=1> b;
       real<lower=-2, upper=1012> c;
     }
+    model {
+      c ~ normal(b, a);
+    }
 
-This produces the following warning:
+This program results in the following warning:
 
     Warning:
       Your Stan program has a parameter c with a lower and upper bound in its

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -35,17 +35,14 @@ Here are the kinds of issues that Pedantic Mode will find (which are described i
 -   *Large or small constant in a distribution.* Very large or very small constants are used as distribution arguments.
 -   *Control flow depends on a parameter.* Branching control flow (like if/else) depends on a parameter value.
 -   *Parameter has multiple twiddles.* A parameter is on the left-hand side of multiple twiddles.
--   *Parameter has zero or multiple priors.* A parameter has more than one prior distribution.
+-   *Parameter has zero or multiple priors.* A parameter has zero or more than one prior distribution.
 -   *Variable is used before assignment.* A variable is used before being assigned a value.
 -   *Strict or nonsensical parameter bounds.* A parameter is given questionable bounds.
 
-Some important limitations of Pedantic Mode are listed at the end of this section.
+Some important limitations of Pedantic Mode are listed at the end of this chapter.
 
 
-## Distribution usage issues
-
-
-### Argument and variate constraint issues
+## Distribution argument and variate constraint issues
 
 When an argument to a built-in distribution certainly does not match that distribution's specification in the [Stan Functions Reference](https://mc-stan.org/docs/functions-reference/index.html), a warning is thrown. This primarily checks if any distribution argument's bounds at declaration, compile-time value, or subtype at declaration (e.g. `simplex`) is incompatible with the domain of the distribution.
 
@@ -68,24 +65,24 @@ This produces the following warning:
       (argument 1), but unb_p was not constrained to be strictly positive.
 
 
-### Special-case distribution issues
+## Special-case distribution issues
 
 Pedantic mode checks for some specific uses of distributions that may indicate a statistical mistake:
 
 
-#### Uniform distributions
+### Uniform distributions
 
 Any use of uniform distribution generates a warning, except when the variate parameter's declared `upper` and `lower` bounds exactly match the uniform distribution bounds.
 In general, assigning a parameter a uniform distribution can create non-differentiable boundary conditions and is not recommended.
 
 
-#### (Inverse-) Gamma distributions
+### (Inverse-) Gamma distributions
 
 Gamma distributions are sometimes used as an attempt to assign an improper prior to a parameter.
 Pedantic mode gives a warning when the Gamma arguments indicate that this may be the case.
 
 
-#### lkj\_corr distribution
+### lkj\_corr distribution
 
 Any use of the `lkj_corr` distribution generates a warning that suggests using the Cholesky variant instead.
 See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for details.
@@ -106,7 +103,7 @@ See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outp
 ## Control flow depends on a parameter
 
 Control flow statements, such as `if`, `for` and `while`, should not depend on the value of the parameters to determine their branching conditions.
-Otherwise, the program may branch differently between iterations, which is likely to introduce discontinuity into the density function.
+This is likely to introduce discontinuity into the density function.
 Pedantic mode generates a warning when any branching condition may depend on a parameter value.
 
 
@@ -128,15 +125,14 @@ This analysis depends on a [*factor graph*](https://en.wikipedia.org/wiki/Factor
 ## Variables used before assignment
 
 A warning is generated when any variable is used before it has been assigned a value.
-This warning is also available as a standalone option to Stanc3, with the flag: `--warn-uninitialized`.
 
 
 ## Strict or nonsensical parameter bounds
 
-Parameters that are have strict `upper` and `lower` bounds can cause unmanageably large gradients in a density function, and may only be justified in a few cased.
+Except when there are logical or physical constraints, it is very unusual for you to be sure that a parameter will fall inside a specified range.
 A warning is generated for all parameters declared with the bounds `<lower=.., upper=..>` except for `<lower=0, upper=1>` or `<lower=-1, upper=1>`.
 
-In addition, a warning is generated when a parameter bound is found to have `upper - lower <= 0`.
+In addition, a warning is generated when a parameter bound is found to have `lower >= upper`.
 
 
 ## Pedantic Mode limitations

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -60,7 +60,7 @@ For example, in the following program:
 The parameter of `poisson` should be strictly positive, but `unb_p` is not constrained to be positive.
 This produces the following warning:
 
-    Warning at 'dist-warn-ex1.stan', line 6, column 14 to column 19:
+    Warning at 'ex-dist-args.stan', line 6, column 14 to column 19:
       A poisson distribution is given parameter unb_p as a rate parameter
       (argument 1), but unb_p was not constrained to be strictly positive.
 
@@ -74,6 +74,29 @@ Pedantic mode checks for some specific uses of distributions that may indicate a
 
 Any use of uniform distribution generates a warning, except when the variate parameter's declared `upper` and `lower` bounds exactly match the uniform distribution bounds.
 In general, assigning a parameter a uniform distribution can create non-differentiable boundary conditions and is not recommended.
+
+For example, in the following program:
+
+    parameters {
+      real a;
+      real<lower=0, upper=1> b;
+    }
+    model {
+      a ~ uniform(0, 1);
+      b ~ uniform(0, 1);
+    }
+
+This produces the following warning:
+
+    Warning at 'uniform-warn.stan', line 6, column 2 to column 20:
+      Parameter a is given a uniform distribution. The uniform distribution is
+      not recommended, for two reasons: (a) Except when there are logical or
+      physical constraints, it is very unusual for you to be sure that a
+      parameter will fall inside a specified range, and (b) The infinite gradient
+      induced by a uniform density can cause difficulties for Stan's sampling
+      algorithm. As a consequence, we recommend soft constraints rather than hard
+      constraints; for example, instead of giving an elasticity parameter a
+      uniform(0,1) distribution, try normal(0.5,0.5).
 
 
 ### (Inverse-) Gamma distributions
@@ -93,11 +116,46 @@ See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for deta
 A warning is generated when a parameter is declared but does not have any effect on the program.
 This is determined by checking whether the value of the `target` variable depends in any way on each of the parameters.
 
+For example, in the following program:
+
+    parameters {
+      real a;
+      real b;
+    }
+    model {
+      a ~ normal(1, 1);
+    }
+
+This produces the following warning:
+
+    Warning:
+      The parameter b was declared but was not used in the density calculation.
+
 
 ## Large or small constants in a distribution
 
 When numbers with magnitude less than 0.1 or greater than 10 are used as arguments to a distribution, it indicates that some parameter is not scaled to unit value, so a warning is thrown.
 See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outputs.html> for a discussion of scaling parameters.
+
+For example, in the following program:
+
+    parameters {
+      real x;
+      real<offset=-100, multiplier=100> y;
+    }
+    model {
+      x ~ normal(-100, 100);
+      y ~ normal(0, 1);
+    }
+
+This produces the following warning:
+
+    Warning at 'constants-warn.stan', line 6, column 14 to column 17:
+      Argument -100 suggests there may be parameters that are not unit scale;
+      consider rescaling with a multiplier (see manual section 22.12).
+    Warning at 'constants-warn.stan', line 6, column 19 to column 22:
+      Argument 100 suggests there may be parameters that are not unit scale;
+      consider rescaling with a multiplier (see manual section 22.12).
 
 
 ## Control flow depends on a parameter
@@ -105,6 +163,38 @@ See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outp
 Control flow statements, such as `if`, `for` and `while`, should not depend on the value of the parameters to determine their branching conditions.
 This is likely to introduce discontinuity into the density function.
 Pedantic mode generates a warning when any branching condition may depend on a parameter value.
+
+For example, in the following program:
+
+    parameters {
+      real a;
+    }
+    model {
+      // x depends on parameter a
+      real x = a * a;
+    
+      int m;
+    
+      // the if-then-else depends on x which depends on a
+      if(x > 0) {
+        //now m depends on x which depends on a
+        m = 1;
+      } else {
+        m = 2;
+      }
+    
+      // for loop depends on m -> x -> a
+      for (i in 0:m) {
+        a ~ normal(i, 1);
+      }
+    }
+
+This produces the following warning:
+
+    Warning at 'param-dep-cf-warn.stan', line 11, column 2 to line 16, column 3:
+      A control flow statement depends on parameter(s): a.
+    Warning at 'param-dep-cf-warn.stan', line 19, column 2 to line 21, column 3:
+      A control flow statement depends on parameter(s): a.
 
 
 ## Parameters with multiple twiddles
@@ -114,6 +204,28 @@ This pattern is not inherently an issue, but it is unusual and may indicate a mi
 
 Pedantic mode only searches for repeated statements, it will not for example generate a warning when a ~ statement is executed repeatedly inside of a loop.
 
+For example, in the following program:
+
+    data {
+      real x;
+    }
+    parameters {
+      real a;
+      real b;
+    }
+    model {
+      a ~ normal(0, 1);
+      a ~ normal(x, 1);
+    
+      b ~ normal(1, 1);
+    }
+
+This produces the following warning:
+
+    Warning at 'multi-twiddle.stan', line 9, column 2 to column 19:
+      The parameter a is on the left-hand side of more than one twiddle
+      statement.
+
 
 ## Parameters with zero or multiple priors
 
@@ -121,10 +233,60 @@ A warning is generated when a parameter appears to have greater than or less tha
 
 This analysis depends on a [*factor graph*](https://en.wikipedia.org/wiki/Factor_graph) representation of a Stan program. A factor F that depends on a parameter P is called a *prior factor for P* if there is no path in the factor graph from F to any data variable except through P.
 
+For example, in the following program:
+
+    data {
+      real x;
+    }
+    parameters {
+      real a;
+      real b;
+      real c;
+      real d;
+    }
+    model
+    {
+      a ~ normal(0, 1); // this is a prior
+      x ~ normal(a, 1); // this is not a prior, since data is involved
+    
+      b ~ normal(x, 1); // this is also not a prior, since data is involved
+    
+      // this is not a prior for c, since data is involved through b
+      // but it is a prior for b, since the data is only involved through b
+      c ~ normal(b, 1);
+    
+      //these are multiple priors:
+      d ~ normal(0, 1);
+      1 ~ normal(d, 1);
+    }
+
+This produces the following warning:
+
+    Warning:
+      The parameter c has no priors.
+    Warning:
+      The parameter d has 2 priors.
+
 
 ## Variables used before assignment
 
 A warning is generated when any variable is used before it has been assigned a value.
+
+For example, in the following program:
+
+    transformed data {
+      real x;
+      if (2 > 1)
+        x = 1;
+      else
+        print("oops");
+      print(x);
+    }
+
+This produces the following warning:
+
+    Warning at 'uninit-warn.stan', line 7, column 8 to column 9:
+      The variable x may not have been assigned a value before its use.
 
 
 ## Strict or nonsensical parameter bounds
@@ -133,6 +295,27 @@ Except when there are logical or physical constraints, it is very unusual for yo
 A warning is generated for all parameters declared with the bounds `<lower=.., upper=..>` except for `<lower=0, upper=1>` or `<lower=-1, upper=1>`.
 
 In addition, a warning is generated when a parameter bound is found to have `lower >= upper`.
+
+For example, in the following program:
+
+    parameters {
+      real<lower=0, upper=1> a;
+      real<lower=-1, upper=1> b;
+      real<lower=-2, upper=1012> c;
+    }
+
+This produces the following warning:
+
+    Warning:
+      Your Stan program has a parameter c with a lower and upper bound in its
+      declaration. These hard constraints are not recommended, for two reasons:
+      (a) Except when there are logical or physical constraints, it is very
+      unusual for you to be sure that a parameter will fall inside a specified
+      range, and (b) The infinite gradient induced by a hard constraint can cause
+      difficulties for Stan's sampling algorithm. As a consequence, we recommend
+      soft constraints rather than hard constraints; for example, instead of
+      constraining an elasticity parameter to fall between 0, and 1, leave it
+      unconstrained and give it a normal(0.5,0.5) prior distribution.
 
 
 ## Pedantic Mode limitations

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -180,7 +180,7 @@ Warning at 'constants-warn.stan', line 6, column 19 to column 22:
 
 ## Control flow depends on a parameter
 
-Control flow statements, such as `if`, `for` and `while`, should not depend on parameters or functions of parameters to determine their branching conditions. This is likely to introduce a discontinuity into the density function. Pedantic mode generates a warning when any branching condition may depend on a parameter value.
+Control flow statements, such as `if`, `for` and `while` should not depend on parameters or functions of parameters to determine their branching conditions. This is likely to introduce a discontinuity into the density function. Pedantic mode generates a warning when any branching condition may depend on a parameter value.
 
 For example, consider the following program.
 

--- a/src/reference-manual/pedantic-mode.Rmd
+++ b/src/reference-manual/pedantic-mode.Rmd
@@ -1,0 +1,177 @@
+
+
+# Pedantic Mode
+
+Pedantic Mode is a compilation option built into Stanc3 that warns you about potential issues in your Stan program.
+
+For example, if you compile the following program with Pedantic Mode:
+
+    data {
+      int N;
+      real x[N];
+    }
+    parameters {
+      real sigma;
+    }
+    model {
+      real mu;
+      x ~ normal(mu, sigma);
+    }
+
+The compiler will print the following to stderr:
+
+    Warning:
+      The parameter sigma has no priors.
+    Warning at 'ped-mode-ex1.stan', line 10, column 14 to column 16:
+      The variable mu may not have been assigned a value before its use.
+    Warning at 'ped-mode-ex1.stan', line 10, column 18 to column 23:
+      A normal distribution is given parameter sigma as a scale parameter
+      (argument 2), but sigma was not constrained to be strictly positive.
+
+Here are the kinds of issues that Pedantic Mode will find (which are described in more detail in following sections):
+
+-   *Distribution usages issues.* Distribution arguments don't match the distribution specification, or some specific distribution is used in an inadvisable way.
+-   *Unused parameter.* A parameter is defined but doesn't contribute to target.
+-   *Large or small constant in a distribution.* Very large or very small constants are used as distribution arguments.
+-   *Control flow depends on a parameter.* Branching control flow (like if/else) depends on a parameter value.
+-   *Parameter has multiple twiddles.* A parameter is on the left-hand side of multiple twiddles.
+-   *Parameter has zero or multiple priors.* A parameter has more than one prior distribution.
+-   *Variable is used before assignment.* A variable is used before being assigned a value.
+-   *Strict or nonsensical parameter bounds.* A parameter is given questionable bounds.
+
+Some important limitations of Pedantic Mode are listed at the end of this section.
+
+
+## Distribution usage issues
+
+
+### Argument and variate constraint issues
+
+<a id="orgd9214d2"></a>
+When an argument to a built-in distribution certainly does not match that distribution's specification in the [Stan Functions Reference](https://mc-stan.org/docs/functions-reference/index.html), a warning is thrown. This primarily checks if any distribution argument's bounds at declaration, compile-time value, or subtype at declaration (e.g. `simplex`) is incompatible with the domain of the distribution.
+
+For example, in the following program:
+
+    parameters {
+      real unb_p;
+      real<lower=0> pos_p;
+    }
+    model {
+      1 ~ poisson(unb_p);
+      1 ~ poisson(pos_p);
+    }
+
+The parameter of `poisson` should be strictly positive, but `unb_p` is not constrained to be positive.
+This produces the following warning:
+
+    Warning at 'dist-warn-ex1.stan', line 6, column 14 to column 19:
+      A poisson distribution is given parameter unb_p as a rate parameter
+      (argument 1), but unb_p was not constrained to be strictly positive.
+
+
+### Special-case distribution issues
+
+<a id="org5f3c7e0"></a>
+Pedantic mode checks for some specific uses of distributions that may indicate a statistical mistake:
+
+
+#### Uniform distributions
+
+Any use of uniform distribution generates a warning, except when the variate parameter's declared `upper` and `lower` bounds exactly match the uniform distribution bounds.
+In general, assigning a parameter a uniform distribution can create non-differentiable boundary conditions and is not recommended.
+
+
+#### (Inverse-) Gamma distributions
+
+Gamma distributions are sometimes used as an attempt to assign an improper prior to a parameter.
+Pedantic mode gives a warning when the Gamma arguments indicate that this may be the case.
+
+
+#### lkj\_corr distribution
+
+Any use of the `lkj_corr` distribution generates a warning that suggests using the Cholesky variant instead.
+See <https://mc-stan.org/docs/functions-reference/lkj-correlation.html> for details.
+
+
+## Unused parameters
+
+<a id="org17b43e7"></a>
+A warning is generated when a parameter is declared but does not have any effect on the program.
+This is determined by checking whether the value of the `target` variable depends in any way on each of the parameters.
+
+
+## Large or small constants in a distribution
+
+<a id="orgb4789bb"></a>
+When numbers with magnitude less than 0.1 or greater than 10 are used as arguments to a distribution, it indicates that some parameter is not scaled to unit value, so a warning is thrown.
+See <https://mc-stan.org/docs/stan-users-guide/standardizing-predictors-and-outputs.html> for a discussion of scaling parameters.
+
+
+## Control flow depends on a parameter
+
+<a id="org76ab7e5"></a>
+Control flow statements, such as `if`, `for` and `while`, should not depend on the value of the parameters to determine their branching conditions.
+Otherwise, the program may branch differently between iterations, which is likely to introduce discontinuity into the density function.
+Pedantic mode generates a warning when any branching condition may depend on a parameter value.
+
+
+## Parameters with multiple twiddles
+
+<a id="orgb60d090"></a>
+A warning is generated when a parameter is found on the left-hand side of more than one ~ statements (or an equivalent `target +=` conditional density statement).
+This pattern is not inherently an issue, but it is unusual and may indicate a mistake.
+
+Pedantic mode only searches for repeated statements, it will not for example generate a warning when a ~ statement is executed repeatedly inside of a loop.
+
+
+## Parameters with zero or multiple priors
+
+<a id="orgc034d9e"></a>
+A warning is generated when a parameter appears to have greater than or less than one prior distribution factor.
+
+This analysis depends on a [*factor graph*](https://en.wikipedia.org/wiki/Factor_graph) representation of a Stan program. A factor F that depends on a parameter P is called a *prior factor for P* if there is no path in the factor graph from F to any data variable except through P.
+
+
+## Variables used before assignment
+
+<a id="org565cee9"></a>
+A warning is generated when any variable is used before it has been assigned a value.
+This warning is also available as a standalone option to Stanc3, with the flag: `--warn-uninitialized`.
+
+
+## Strict or nonsensical parameter bounds
+
+<a id="org2a84a6b"></a>
+Parameters that are have strict `upper` and `lower` bounds can cause unmanageably large gradients in a density function, and may only be justified in a few cased.
+A warning is generated for all parameters declared with the bounds `<lower=.., upper=..>` except for `<lower=0, upper=1>` or `<lower=-1, upper=1>`.
+
+In addition, a warning is generated when a parameter bound is found to have `upper - lower <= 0`.
+
+
+## Pedantic Mode limitations
+
+<a id="org9638524"></a>
+
+
+#### Constant values are sometimes uncomputable
+
+Pedantic mode attempts to evaluate expressions down to literal values so that they can be used to generate warnings.
+For example, in the code `normal(x, 1 - 2)`, the expression `1 - 2` will be evaluated to `-1`, which is not a valid variance argument so a warning is generated.
+However, this strategy is limited; it is often impossible to fully evaluate expressions in finite time.
+
+
+#### Container types
+
+Currently, indexed variables are not handled intelligently, so they are treated as monolithic variables.
+Each analysis treats indexed variables conservatively (erring toward generating fewer warnings).
+
+
+#### Data variables
+
+The declaration information for `data` variables is currently not considered, so using `data` as incompatible arguments to distributions may not generate the appropriate warnings.
+
+
+#### Control flow dependent on parameters in nested functions
+
+If a parameter is passed as an argument to a user-defined function within another user-defined function, and then some control flow depends on that argument, the appropriate warning will not be thrown.
+


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [ ] Declare copyright holder and open-source license: see below

#### Summary

I added the pedantic mode doc to the end of the reference manual (after Diagnostic Mode). Let me know what you think.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
