### PR TITLE
Clarify the double exponential distribution docs

### DIFF
--- a/src/bibtex/all.bib
+++ b/src/bibtex/all.bib
@@ -1564,3 +1564,19 @@ Year = {2000}}
   doi="10.1007/s00211-008-0195-1",
   url="https://doi.org/10.1007/s00211-008-0195-1"
 }
+
+@article{Ding:18,
+  author = {Peng Ding and Joseph K. Blitzstein},
+  title = {On the Gaussian Mixture Representation of the Laplace Distribution},
+  journal = {The American Statistician},
+  volume = {72},
+  number = {2},
+  pages = {172-174},
+  year  = {2018},
+  publisher = {Taylor & Francis},
+  doi = {10.1080/00031305.2017.1291448},
+  URL = {https://doi.org/10.1080/00031305.2017.1291448},
+  eprint = {https://doi.org/10.1080/00031305.2017.1291448}
+}
+
+

--- a/src/functions-reference/unbounded_continuous_distributions.Rmd
+++ b/src/functions-reference/unbounded_continuous_distributions.Rmd
@@ -491,10 +491,12 @@ section [exponential distribution](#exponential-distribution)), which is paramet
 terms of inverse scale.
 
 The double-exponential distribution can be defined as a compound
-exponential-normal distribution.  Specifically, if \[ \alpha \sim
-\mathsf{Exponential}\left( \frac{1}{\lambda} \right) \] and \[ \beta
-\sim \mathsf{Normal}(\mu, \alpha), \] then \[ \beta \sim
-\mathsf{DoubleExponential}(\mu, \lambda). \] This may be used to code
+exponential-normal distribution. Using the inverse scale parameterization for 
+the exponential distribution, and the standard deviation parameterization for 
+the normal distribution, one can write \[ \alpha \sim
+\mathsf{Exponential}\left( \lambda \right) \] and \[ \beta
+\sim \mathsf{Normal}(\mu, \sqrt{\alpha}), \] then \[ \beta \sim
+\mathsf{DoubleExponential}(\mu, \frac{1}{\lambda} ). \] This may be used to code
 a non-centered parameterization by taking \[ \beta^{\text{raw}} \sim
 \mathsf{Normal}(0, 1) \] and defining \[ \beta = \mu + \alpha \,
 \beta^{\text{raw}}. \]

--- a/src/functions-reference/unbounded_continuous_distributions.Rmd
+++ b/src/functions-reference/unbounded_continuous_distributions.Rmd
@@ -487,19 +487,20 @@ If $\mu \in \mathbb{R}$ and $\sigma \in \mathbb{R}^+$, then for $y \in
 \frac{1}{2\sigma}   \exp \left( - \, \frac{|y - \mu|}{\sigma} \right)
 . \] Note that the double exponential distribution is parameterized in
 terms of the scale, in contrast to the exponential distribution (see
-section [exponential distribution](#exponential-distribution)), which is parameterized in
-terms of inverse scale.
+section [exponential distribution](#exponential-distribution)), which is 
+parameterized in terms of inverse scale.
 
 The double-exponential distribution can be defined as a compound
-exponential-normal distribution. Using the inverse scale parameterization for 
-the exponential distribution, and the standard deviation parameterization for 
-the normal distribution, one can write \[ \alpha \sim
-\mathsf{Exponential}\left( \lambda \right) \] and \[ \beta
-\sim \mathsf{Normal}(\mu, \sqrt{\alpha}), \] then \[ \beta \sim
-\mathsf{DoubleExponential}(\mu, \frac{1}{\lambda} ). \] This may be used to code
+exponential-normal distribution [@Ding:18]. Using the inverse scale 
+parameterization for the exponential distribution, and the standard deviation 
+parameterization for the normal distribution, one can write \[ \alpha \sim
+\mathsf{Exponential}\left( \frac{1}{2 \sigma^2} \right) \] and \[ \beta \mid 
+\alpha \sim \mathsf{Normal}(\mu, \sqrt{\alpha}), \] then \[ \beta \sim
+\mathsf{DoubleExponential}(\mu, \sigma ). \] This may be used to code
 a non-centered parameterization by taking \[ \beta^{\text{raw}} \sim
 \mathsf{Normal}(0, 1) \] and defining \[ \beta = \mu + \alpha \,
 \beta^{\text{raw}}. \]
+
 
 ### Sampling Statement
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

From [shira on discourse](https://discourse.mc-stan.org/t/error-in-stan-documentation-about-double-exponential/15962/).

This PR aligns the parameterisation of the exponential distribution, normal distribution and double-exponential distribution with both the double exponential doc, and the rest of the Stan doc.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Andrew Manderson 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
