### PR TITLE
Add matrix_pow and elt_pow doc

### DIFF
--- a/src/functions-reference/matrix_operations.Rmd
+++ b/src/functions-reference/matrix_operations.Rmd
@@ -374,6 +374,60 @@ The elementwise quotient of y and x
 `matrix` **`operator./`**`(real x, matrix y)`<br>\newline
 The elementwise quotient of y and x
 
+<!-- vector; operator.^; (vector x, vector y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (vector x, vector y): vector}|hyperpage}
+
+`vector` **`operator.^`**`(vector x, vector y)`<br>\newline
+The elementwise power of y and x
+
+<!-- vector; operator.^; (vector x, real y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (vector x, real y): vector}|hyperpage}
+
+`vector` **`operator.^`**`(vector x, real y)`<br>\newline
+The elementwise power of y and x
+
+<!-- vector; operator.^; (real x, vector y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (real x, vector y): vector}|hyperpage}
+
+`vector` **`operator.^`**`(real x, vector y)`<br>\newline
+The elementwise power of y and x
+
+<!-- row_vector; operator.^; (row_vector x, row_vector y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (row\_vector x, row\_vector y): row\_vector}|hyperpage}
+
+`row_vector` **`operator.^`**`(row_vector x, row_vector y)`<br>\newline
+The elementwise power of y and x
+
+<!-- row_vector; operator.^; (row_vector x, real y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (row\_vector x, real y): row\_vector}|hyperpage}
+
+`row_vector` **`operator.^`**`(row_vector x, real y)`<br>\newline
+The elementwise power of y and x
+
+<!-- row_vector; operator.^; (real x, row_vector y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (real x, row\_vector y): row\_vector}|hyperpage}
+
+`row_vector` **`operator.^`**`(real x, row_vector y)`<br>\newline
+The elementwise power of y and x
+
+<!-- matrix; operator.^; (matrix x, matrix y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (matrix x, matrix y): matrix}|hyperpage}
+
+`matrix` **`operator.^`**`(matrix x, matrix y)`<br>\newline
+The elementwise power of y and x
+
+<!-- matrix; operator.^; (matrix x, real y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (matrix x, real y): matrix}|hyperpage}
+
+`matrix` **`operator.^`**`(matrix x, real y)`<br>\newline
+The elementwise power of y and x
+
+<!-- matrix; operator.^; (real x, matrix y); -->
+\index{{\tt \bfseries operator\_elt\_pow }!{\tt (real x, matrix y): matrix}|hyperpage}
+
+`matrix` **`operator.^`**`(real x, matrix y)`<br>\newline
+The elementwise power of y and x
+
 ## Transposition Operator
 
 Matrix transposition is represented using a postfix operator.
@@ -1390,6 +1444,16 @@ algebraically equivalent to the less efficient form `matrix_exp(A) * B`.
 `matrix` **`scale_matrix_exp_multiply`**`(real t, matrix A, matrix B)`<br>\newline
 The multiplication of matrix exponential of tA and matrix B;
 algebraically equivalent to the less efficient form `matrix_exp(t * A) * B`.
+
+### Matrix Power
+
+Returns the nth power of the specific matrix: \[ M^n = M_1 * ... * M_n \]
+
+<!-- matrix; matrix_power; (matrix A, int B); -->
+\index{{\tt \bfseries matrix\_power }!{\tt (matrix A, int B): matrix}|hyperpage}
+
+`matrix` **`matrix_power`**`(matrix A, int B)`<br>\newline
+Matrix A raised to the power B.
 
 ### Linear Algebra Functions
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR introduces the documentation for the new ```.^``` elementwise ```pow``` operator and for the ```matrix_power``` function that was not previously exposed. The stanc3 PR for the signatures is [here](https://github.com/stan-dev/stanc3/pull/641)

My main query was around the signatures for the nested containers. For example, the following are legal:
```
vector[] .^ vector[]
int .^ matrix[]
row_vector[] .^ real
```

Should I add these as separate signatures in the documentation, or should the current doc just use ```vectors``` rather than ```vector```?

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
