### PR TITLE
recommend JSON and write_stan_json

### DIFF
--- a/src/cmdstan-guide/json_apdx.Rmd
+++ b/src/cmdstan-guide/json_apdx.Rmd
@@ -4,6 +4,15 @@ CmdStan can use JSON format for input data for both model data and
 parameters. Model data is read in by the model constructor. Model
 parameters are used to initialize the sampler and optimizer.
 
+
+## Creating JSON Files
+
+You can create the JSON file yourself using the guidelines below, but a more
+convenient way to create a JSON file for use with CmdStan is to use the
+[`write_stan_json()`](http://mc-stan.org/cmdstanr/reference/write_stan_json) 
+function provided by the CmdStanR interface.
+
+
 ## JSON Syntax Summary
 
 JSON is a data interchange notation, defined by an

--- a/src/cmdstan-guide/json_apdx.Rmd
+++ b/src/cmdstan-guide/json_apdx.Rmd
@@ -9,7 +9,7 @@ parameters are used to initialize the sampler and optimizer.
 
 You can create the JSON file yourself using the guidelines below, but a more
 convenient way to create a JSON file for use with CmdStan is to use the
-[`write_stan_json()`](http://mc-stan.org/cmdstanr/reference/write_stan_json) 
+[`write_stan_json()`](https://mc-stan.org/cmdstanr/reference/write_stan_json) 
 function provided by the CmdStanR interface.
 
 

--- a/src/cmdstan-guide/rdump_apdx.Rmd
+++ b/src/cmdstan-guide/rdump_apdx.Rmd
@@ -1,5 +1,8 @@
 # RDump Format for CmdStan {#rdump}
 
+**NOTE:** Although the RDump format is still supported, I/O with JSON is faster
+and recommended. See the [chapter on JSON](#json) for more details.
+
 RDump format can be used to represent values for Stan variables.
 This format was introduced in SPLUS and is used in R, JAGS,
 and in BUGS (but with a different ordering).
@@ -10,7 +13,7 @@ There are three kinds of variable declarations:
  - scalars
  - sequences
  - general arrays
-
+ 
 ## Creating Dump Files
 
 Dump files can be created from R using RStan,


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

There is some confusion about the RDump vs JSON formats (see e.g. https://discourse.mc-stan.org/t/cmdstanr-writing-to-rdump/16949), so this PR adds a recommendation in the RDump chapter to use JSON instead for speed, and also mentions the cmdstanr::write_stan_json() function (as an alternative to rstan::stan_rdump()). 

@mitzimorris Did I edit the correct files? Anything else I should do? 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
