### PR TITLE
Bugfix/251 users guide measurement error models formats

### DIFF
--- a/src/stan-users-guide/measurement-error.Rmd
+++ b/src/stan-users-guide/measurement-error.Rmd
@@ -50,7 +50,15 @@ model {
 ```
 
 
-Now suppose that the true values of the predictors $x_n$ are not known, but for each $n$, a measurement $x^{\textrm{meas}}_n$ of $x_n$ is available.  If the error in measurement can be modeled, the measured value $x^{\textrm{meas}}_n$ can be modeled in terms of the true value $x_n$ plus measurement noise.  The true value $x_n$ is treated as missing data and estimated along with other quantities in the model.  A  simple approach is to assume the measurement error is normal with known deviation $\tau$.  This leads to the following regression model with constant measurement error.
+Now suppose that the true values of the predictors $x_n$ are not
+known, but for each $n$, a measurement $x^{\textrm{meas}}_n$ of $x_n$
+is available.  If the error in measurement can be modeled, the
+measured value $x^{\textrm{meas}}_n$ can be modeled in terms of the
+true value $x_n$ plus measurement noise.  The true value $x_n$ is
+treated as missing data and estimated along with other quantities in
+the model.  A simple approach is to assume the measurement error is
+normal with known deviation $\tau$.  This leads to the following
+regression model with constant measurement error.
 
 ```
 data {
@@ -104,15 +112,14 @@ by rounding down to the nearest integer.
 
 Exercise 3.5(b) by @GelmanEtAl:2013 provides an example.
 
-\begin{quote}
-  3.5. \ Suppose we weigh an object five times and measure
-  weights, rounded to the nearest pound, of 10, 10, 12, 11, 9.  Assume
-  the unrounded measurements are normally distributed with a
-  noninformative prior distribution on $\mu$ and $\sigma^2$.
-  \\[4pt]
-  (b) \ Give the correct posterior distribution for $(\mu, \sigma^2)$,
-  treating the measurements as rounded.
-\end{quote}
+>  3.5. Suppose we weigh an object five times and measure
+>  weights, rounded to the nearest pound, of 10, 10, 12, 11, 9.
+>  Assume the unrounded measurements are normally distributed with a
+>  noninformative prior distribution on $\mu$ and $\sigma^2$.
+>
+>  (b) Give the correct posterior distribution for $(\mu, \sigma^2)$,
+>  treating the measurements as rounded.
+
 
 Letting $z_n$ be the unrounded measurement for $y_n$, the problem
 as stated assumes the likelihood

--- a/src/stan-users-guide/odes.Rmd
+++ b/src/stan-users-guide/odes.Rmd
@@ -42,7 +42,6 @@ $$
 \frac{d}{dt} y_1 = y_2 \\
 \frac{d}{dt} y_2 = -y_1 - \theta y_2
 $$
-<a name="id:ode-sho.equation"></a>
 
 The state equations implicitly defines the state at future times
 as a function of an initial state and the system parameters.
@@ -155,7 +154,6 @@ generated quantities {
   }
 }
 ```
-<a name="id:sho-sim.figure"></a>
 
 The system parameters `theta` and initial state `y0` are read in as data
 along with the initial time `t0` and observation times `ts`. The ODE is solved
@@ -198,10 +196,10 @@ Because all none of the input arguments are a function of parameters, the ODE
 solver is called in the generated quantities block. The random measurement noise
 is added to each of the `T` outputs with `normal_rng`.
 
-```{r fig.cap="Typical realization of harmonic oscillator trajectory (`y_sim`)"}
-knitr::include_graphics("img/sho-ode-trajectory.png")
+```{r  include = TRUE, echo = FALSE, fig.align = "center", fig.cap = "Typical realization of harmonic oscillator trajectory."}
+knitr::include_graphics("./img/sho-ode-trajectory.png", auto_pdf = TRUE)
 ```
-<a name="id:sho-trajectory.figure"></a>
+
 
 ### Estimating System Parameters and Initial State {-}
 
@@ -209,6 +207,7 @@ These ten noisy observations of the state can be used to estimate the friction
 parameter, $\theta$, the initial conditions, $y(t_0, \theta)$, and the scale of
 the noise in the problem. The full Stan model is:
 
+\newpage
 ```
 functions {
   vector sho(real t,
@@ -240,7 +239,6 @@ model {
     y[t] ~ normal(mu[t], sigma);
 }
 ```
-<a name="id:sho-both.figure"></a>
 
 Because the solves are now a function of model parameters, the `ode_rk45`
 call is now made in the model block. There are half-normal priors on the

--- a/src/stan-users-guide/odes.Rmd
+++ b/src/stan-users-guide/odes.Rmd
@@ -42,6 +42,7 @@ $$
 \frac{d}{dt} y_1 = y_2 \\
 \frac{d}{dt} y_2 = -y_1 - \theta y_2
 $$
+<a name="id:ode-sho.equation"></a>
 
 The state equations implicitly defines the state at future times
 as a function of an initial state and the system parameters.
@@ -154,6 +155,7 @@ generated quantities {
   }
 }
 ```
+<a name="id:sho-sim.figure"></a>
 
 The system parameters `theta` and initial state `y0` are read in as data
 along with the initial time `t0` and observation times `ts`. The ODE is solved
@@ -199,7 +201,7 @@ is added to each of the `T` outputs with `normal_rng`.
 ```{r  include = TRUE, echo = FALSE, fig.align = "center", fig.cap = "Typical realization of harmonic oscillator trajectory."}
 knitr::include_graphics("./img/sho-ode-trajectory.png", auto_pdf = TRUE)
 ```
-
+<a name="id:sho-trajectory.figure"></a>
 
 ### Estimating System Parameters and Initial State {-}
 

--- a/src/stan-users-guide/odes.Rmd
+++ b/src/stan-users-guide/odes.Rmd
@@ -241,6 +241,7 @@ model {
     y[t] ~ normal(mu[t], sigma);
 }
 ```
+<a name="id:sho-both.figure"></a>
 
 Because the solves are now a function of model parameters, the `ode_rk45`
 call is now made in the model block. There are half-normal priors on the


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes problem with pdf - triggered by underscore in figure caption.

also fixes problems observed in chapter 6 where latex `{quote}` section
not showing up in HTML version of the docs.  (found this because reported bug was in section
with similar name and looked at wrong file first).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University




By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
