### PR TITLE
Added docs for ldexp and log_modified_bessel_first_kind

### DIFF
--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -1233,7 +1233,7 @@ Vectorized implementation of the `bessel_second_kind` function
 
 `real` **`modified_bessel_first_kind`**`(int v, real z)`<br>\newline
 Return the modified Bessel function of the first kind with order v
-applied to z defined for all z and v. \[
+applied to z defined for all z and integer v. \[
 \mathrm{modified\_bessel\_first\_kind}(v,z) = I_v(z) \] where \[
 {I_v}(z) = \left(\frac{1}{2}z\right)^v\sum_{k=0}^\infty
 \frac{\left(\frac{1}{4}z^2\right)^k}{k!\Gamma(v+k+1)} \]
@@ -1244,12 +1244,25 @@ applied to z defined for all z and v. \[
 `R` **`modified_bessel_first_kind`**`(T1 x, T2 y)`<br>\newline
 Vectorized implementation of the `modified_bessel_first_kind` function
 
+<!-- real; log_modified_bessel_first_kind; (real v, real z); -->
+\index{{\tt \bfseries log\_modified\_bessel\_first\_kind }!{\tt (real v, real z): real}|hyperpage}
+
+`real` **`log_modified_bessel_first_kind`**`(real v, real z)`<br>\newline
+Return the log of the modified Bessel function of the first kind. v does
+not have to be an integer.
+
+<!-- R; log_modified_bessel_first_kind; (T1 x, T2 y); -->
+\index{{\tt \bfseries log\_modified\_bessel\_first\_kind }!{\tt (T1 x, T2 y): R}|hyperpage}
+
+`R` **`log_modified_bessel_first_kind`**`(T1 x, T2 y)`<br>\newline
+Vectorized implementation of the `log_modified_bessel_first_kind` function
+
 <!-- real; modified_bessel_second_kind; (int v, real z); -->
 \index{{\tt \bfseries modified\_bessel\_second\_kind }!{\tt (int v, real z): real}|hyperpage}
 
 `real` **`modified_bessel_second_kind`**`(int v, real z)`<br>\newline
 Return the modified Bessel function of the second kind with order v
-applied to z defined for positive z and v. \[
+applied to z defined for positive z and integer v. \[
 \mathrm{modified\_bessel\_second\_kind}(v,z) = \begin{cases} K_v(z) &
 \text{if } z > 0 \\ \textrm{error} & \text{if } z \leq 0 \end{cases}
 \] where \[ {K_v}(z) = \frac{\pi}{2}\cdot\frac{I_{-v}(z) -
@@ -1361,6 +1374,19 @@ _**Warning:**_ This function is deprecated and should be replaced with
 
 `R` **`multiply_log`**`(T1 x, T2 y)`<br>\newline
 Vectorized implementation of the `multiply_log` function
+
+<!-- real; ldexp; (real x, int y); -->
+\index{{\tt \bfseries ldexp }!{\tt (real x, int y): real}|hyperpage}
+
+`real` **`ldexp`**`(real x, int y)`<br>\newline
+Return the product of x and two raised to the y power. \[
+\text{ldexp}(x,y) = x 2^y  \]
+
+<!-- R; ldexp; (T1 x, T2 y); -->
+\index{{\tt \bfseries ldexp }!{\tt (T1 x, T2 y): R}|hyperpage}
+
+`R` **`ldexp`**`(T1 x, T2 y)`<br>\newline
+Vectorized implementation of the `ldexp` function
 
 <!-- real; lmultiply; (real x, real y); -->
 \index{{\tt \bfseries lmultiply }!{\tt (real x, real y): real}|hyperpage}


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

@andrjohns I just went through the binary functions list and tested them. Everything worked great, but these two functions didn't have doc. I assume since they exist and you vectorized them we want to expose them!

Edit: It seemed weird to be `log_modified_bessel_first_kind` supported reals in the first argument but `modified_bessel_first_kind` doesn't. We can handle that separately: https://github.com/stan-dev/math/issues/2153

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
