### PR TITLE
sig_figs, troubleshooting for CmdStan guide

### DIFF
--- a/src/cmdstan-guide/command_line_options.Rmd
+++ b/src/cmdstan-guide/command_line_options.Rmd
@@ -69,7 +69,13 @@ The keyword value pair `refresh=<int>` specifies the
 number of iterations between progress messages written to the terminal window.
 The default value is 100 iterations.
 
-**Note:** Numeric values in the Stan CSV output and diagnostics file provide only 6 decimal places of precision.
+The keyword value pair `sig_figs=<int>` specifies the 
+number of significant digits for all numerical values in the output files.
+Allowable values are between 1 and 18, which is the maximum amount of precision
+available for 64-bit floating point arithmetic.
+The default value is 6. &nbsp;
+***Note:*** increasing `sig_figs` above the default will increase the size of
+the output CSV files accordingly.
 
 
 ## Initialize Model Parameters Argument

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -14,7 +14,7 @@ On Windows, `mingw32-make` is installed as part of RTools: https://cran.rstudio.
 
 - The CmdStan C++ source code and libraries.
 
-    + [CmdStan releases](https://github.com/stan-dev/cmdstan/releases)  are available from GitHub as a compressed tarfile containing all C++ source code and libraries.  The most recent CmdStan release is always availabe as https://github.com/stan-dev/cmdstan/releases/latest.
+    + [CmdStan releases](https://github.com/stan-dev/cmdstan/releases)  are available from GitHub as a compressed tarfile containing all C++ source code and libraries.  The most recent CmdStan release is always available as https://github.com/stan-dev/cmdstan/releases/latest.
 
     + To use the current development version you can [clone the GitHub repo](#git-clone.section).
 
@@ -124,7 +124,7 @@ to the `PATH` environment variable.  If you have `Rtools40`, these should be:
 C:\RTools\RTools40\usr\bin
 C:\RTools\RTools40\mingw64\bin
 ```
-If you have and earlier version of RTools, e.g., RTools 3.6, use `RTools36` istead of `RTools40` in the above paths.
+If you have and earlier version of RTools, e.g., RTools 3.6, use `RTools36` instead of `RTools40` in the above paths.
 See [these instructions](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/)
 for details on changing the `PATH`.
 
@@ -180,7 +180,7 @@ be preceded by zero or more Makefile variable name=value pairs.
 For example to compile `../my_dir/my_program.stan` for an OpenCL (GPU) machine,
 the makefile variable `STAN_OPENCL` is set to `TRUE`:
 ```
-> make STAN_OPENCL=TRUE ../my_dir/my_program
+> make STAN_OPENCL=TRUE ../my_dir/my_program    # mingw32-make if in Windows
 ```
 Makefile variables can also be set by creating a file named `local` in the
 CmdStan `make` subdirectory which contains a list of `<VARIABLE>=<VALUE>` pairs,
@@ -189,7 +189,7 @@ one per line.  The complete set of Makefile variables can be found in file
 
 When invoked without any arguments at all, Make prints a help message:
 ```
-> make
+> make    # mingw32-make if in Windows
 --------------------------------------------------------------------------------
 CmdStan v2.23.0 help
 
@@ -272,7 +272,7 @@ command line interface and supporting libraries:
 ```
 > git clone https://github.com/stan-dev/cmdstan.git --recursive
 > cd cmdstan
-> make build
+> make build    # mingw32-make if in Windows
 ```
 
 The resulting set of directories should have the same structure as the release:
@@ -319,13 +319,13 @@ and compiles all necessary C++ libraries.
 
 ```
 > cd <cmdstan-home>
-> make build
+> make build    # mingw32-make if in Windows
 ```
 
 If your computer has multiple cores and sufficient ram, the build process
 can be parallelized by providing the `-j` option. For example, to build on 4 cores, type:
 ```
-> make -j4 build
+> make -j4 build    # mingw32-make if in Windows
 ```
 
 When `make build` is successful, the directory `<cmdstan-home>/bin/`
@@ -353,20 +353,20 @@ in order to these setting to take effect.
 absolute path to the Intel TBB library when linking into Stan programs.)
 
 
-## Trouble-shooting the installation
+## Checking the Stan compiler
 
 To check that the CmdStan installation is complete
 and in working order, run the following series of commands:
 
 ```
 # compile the example
-> make examples/bernoulli/bernoulli
+> make examples/bernoulli/bernoulli    # mingw32-make if in Windows
 
 # fit to provided data (results of 10 trials, 2 out of 10 successes)
 > ./examples/bernoulli/bernoulli sample data file=examples/bernoulli/bernoulli.data.json
 
 # default output written to file `output.csv`,
-# default num_samples is 1000, output file should have approx 1050 lines
+# default num_samples is 1000, output file should have approx. 1050 lines
 > ls -l output.csv
 
 # run the `bin/stansummary utility to summarize parameter estimates
@@ -375,14 +375,61 @@ and in working order, run the following series of commands:
 The sample data in file `bernoulli.json.data` specifies 2 out of 10 successes, therefore
 the range `mean(theta)`$\pm$`sd(theta)` should include 0.2.
 
+## Troubleshooting the installation
+
 Updates to CmdStan or changes in compiler options may result in errors
 when trying to compile a Stan program.  In some cases, these can be resolved
-by removing the existing CmdStan build and recompiling.
-The Makefile target `clean-all` should be run before rebuilding CmdStan:
+by removing the existing CmdStan binaries and recompiling.
+
+To do this, you must run the makefile commands from the `<cmdstan-home>` directory:
+
 ```
-> make clean-all
+> cd <cmdstan-home>
+> make clean-all    # mingw32-make if in Windows
 > make build
 ```
+
+### Common problems and how to resolve them
+
+This section contains errors reported on https://discourse.mc-stan.org and the proposed solutions.
+
+- Problem:  model compilation fails, error message about PCH file, e.g.,
+
+```
+error: PCH file uses an older PCH format that is no longer supported
+```
+
+To speed up compilation, the Stan makefile pre-compiles parts of the core Stan library.
+This error message occurs when the compiler tries to use an out-of-date pre-compiled header file,
+(possibly found in a system cache). 
+In this case, clean and rebuild CmdStan, as shown in the previous section.
+
+
+#### Windows-specific errors
+
+- Problem: C++ toolchain installed, call to `mingw32-make` fails with error message:
+
+```
+‘mingw32-make’ is not recognised as an internal or external command
+```
+
+- Solution:  call utility `pacman`:
+
+```
+pacman -Sy mingw-w64-x86_64-make
+```
+
+See: https://discourse.mc-stan.org/t/cmdstan-installation-on-windows/11287/6
+
+
+- Problem: compilation fails with message:
+
+```
+‘cut’ is not recognized as an internal or external command, operable program or batch file.
+```
+
+- Solution:  add `mingw_64/bin` directory to the user `PATH` environment variable, discussion here:
+https://discourse.mc-stan.org/t/errors-when-using-cmdstan-model/14984/21?
 
 
 [^1]:

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -200,7 +200,7 @@ Make targets can be preceded by any number of Makefile variable name=value pairs
 For example, to compile `../my_dir/my_program.stan` for an OpenCL (GPU) machine,
 set the makefile variable `STAN_OPENCL` to `TRUE`:
 ```
-> make STAN_OPENCL=TRUE ../my_dir/my_program    # mingw32-make if in Windows
+> make STAN_OPENCL=TRUE ../my_dir/my_program    # on Windows use mingw32-make
 ```
 Makefile variables can also be set by creating a file named `local` in the
 CmdStan `make` subdirectory which contains a list of `<VARIABLE>=<VALUE>` pairs,
@@ -215,7 +215,7 @@ __Make Targets__
 
 When invoked without any arguments at all, Make prints a help message:
 ```
-> make    # mingw32-make if in Windows
+> make    # on Windows use mingw32-make
 --------------------------------------------------------------------------------
 CmdStan v2.23.0 help
 
@@ -298,7 +298,7 @@ command line interface and supporting libraries:
 ```
 > git clone https://github.com/stan-dev/cmdstan.git --recursive
 > cd cmdstan
-> make build    # mingw32-make if in Windows
+> make build    # on Windows use mingw32-make
 ```
 
 The resulting set of directories should have the same structure as the release:
@@ -345,13 +345,13 @@ and compiles all necessary C++ libraries.
 
 ```
 > cd <cmdstan-home>
-> make build    # mingw32-make if in Windows
+> make build    # on Windows use mingw32-make
 ```
 
 If your computer has multiple cores and sufficient ram, the build process
 can be parallelized by providing the `-j` option. For example, to build on 4 cores, type:
 ```
-> make -j4 build    # mingw32-make if in Windows
+> make -j4 build    # on Windows use mingw32-make
 ```
 
 When `make build` is successful, the directory `<cmdstan-home>/bin/`
@@ -386,7 +386,7 @@ and in working order, run the following series of commands:
 
 ```
 # compile the example
-> make examples/bernoulli/bernoulli    # mingw32-make if in Windows
+> make examples/bernoulli/bernoulli    # on Windows use mingw32-make
 
 # fit to provided data (results of 10 trials, 2 out of 10 successes)
 > ./examples/bernoulli/bernoulli sample data file=examples/bernoulli/bernoulli.data.json
@@ -411,7 +411,7 @@ To do this, you must run the makefile commands from the `<cmdstan-home>` directo
 
 ```
 > cd <cmdstan-home>
-> make clean-all    # mingw32-make if in Windows
+> make clean-all    # on Windows use mingw32-make
 > make build
 ```
 

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -94,7 +94,7 @@ CmdStan requires g++ at 4.9.3 or later.  Trying to install later versions of g++
 or `macports` is no longer recommended; use the XCode toolchain.
 
 
-### Windows:  `g++` and `mingw32-make`
+### Windows:  `g++` and `mingw32-make`  {#windows-make}
 
 The Windows toolchain consists of programs `g++`, the C++ compiler,
 and `mingw32-make`, the GNU-Make utility.
@@ -124,7 +124,13 @@ to the `PATH` environment variable.  If you have `Rtools40`, these should be:
 C:\RTools\RTools40\usr\bin
 C:\RTools\RTools40\mingw64\bin
 ```
-If you have and earlier version of RTools, e.g., RTools 3.6, use `RTools36` instead of `RTools40` in the above paths.
+
+If you have and earlier version of RTools, use `RTools35`:
+```
+C:\RTools\RTools35\usr\bin
+C:\RTools\RTools35\mingw64\bin
+```
+
 See [these instructions](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/)
 for details on changing the `PATH`.
 
@@ -405,17 +411,20 @@ error: PCH file uses an older PCH format that is no longer supported
 In this case, clean and rebuild CmdStan, as shown in the previous section.
 
 
-**Windows: ‘mingw32-make’ is not recognised**
+**Windows: 'mingw32-make', 'g++', or 'cut" is not recognised**
 
-If the C++ toolchain has been installed but no properly registered,
-the call to `mingw32-make` will fail with the error message:
-
+If the C++ toolchain has been installed but not properly registered,
+then the call to `mingw32-make` or calls to system utilities during
+the build process will fail with an error message, e.g.:
 ```
 ‘mingw32-make’ is not recognised as an internal or external command
 ```
 
-The solution is to call utility `pacman` as follows:
+To fix this, you should make sure that the RTools installation is
+in your `PATH` environment variable, as described in the [RTools section](#windows-make).
 
+In addition, if you have the RTools 4.0 toolchain, then call the utility `pacman`
+to register the right version of make:
 ```
 pacman -Sy mingw-w64-x86_64-make
 ```

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -196,10 +196,9 @@ make <flags> <variables> <targets>
 
 __Makefile Variables__
 
-Make is invoked with a list of target names which can
-be preceded by zero or more Makefile variable name=value pairs.
-For example to compile `../my_dir/my_program.stan` for an OpenCL (GPU) machine,
-the makefile variable `STAN_OPENCL` is set to `TRUE`:
+Make targets can be preceded by any number of Makefile variable name=value pairs.
+For example, to compile `../my_dir/my_program.stan` for an OpenCL (GPU) machine,
+set the makefile variable `STAN_OPENCL` to `TRUE`:
 ```
 > make STAN_OPENCL=TRUE ../my_dir/my_program    # mingw32-make if in Windows
 ```

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -403,11 +403,11 @@ the range `mean(theta)`$\pm$`sd(theta)` should include 0.2.
 
 ## Troubleshooting the installation
 
-Updates to CmdStan or changes in compiler options may result in errors
-when trying to compile a Stan program.  In some cases, these can be resolved
-by removing the existing CmdStan binaries and recompiling.
-
-To do this, you must run the makefile commands from the `<cmdstan-home>` directory:
+Updates to CmdStan, changes in compiler options, or updates to the
+C++ toolchain may result in errors when trying to compile a Stan program.
+Often, these problems can be resolved by removing the existing CmdStan binaries
+and recompiling.  To do this, you must run the makefile commands
+from the `<cmdstan-home>` directory:
 
 ```
 > cd <cmdstan-home>
@@ -431,15 +431,13 @@ error: PCH file uses an older PCH format that is no longer supported
 In this case, clean and rebuild CmdStan, as shown in the previous section.
 
 
-**Windows: 'mingw32-make', 'g++', or 'cut" is not recognised**
+**Windows: 'mingw32-make' is not recognised**
 
 If the C++ toolchain has been installed but not properly registered,
-then the call to `mingw32-make` or calls to system utilities during
-the build process will fail with an error message, e.g.:
+then the call to `mingw32-make` will result in error message:
 ```
-‘mingw32-make’ is not recognised as an internal or external command
+'mingw32-make' is not recognised as an internal or external command
 ```
-
 To fix this, you should make sure that the RTools installation is
 in your `PATH` environment variable, as described in the [RTools section](#windows-make).
 
@@ -448,19 +446,16 @@ to register the right version of make:
 ```
 pacman -Sy mingw-w64-x86_64-make
 ```
-
 See: https://discourse.mc-stan.org/t/cmdstan-installation-on-windows/11287/6
 
 
-**Windows: compiler error message ‘cut’ is not recognized**
+**Windows: 'g++' or 'cut' is not recognized**
 
 The CmdStan makefile uses a few shell utilities which might not be present in Windows,
 resulting in the error message:
-
 ```
-‘cut’ is not recognized as an internal or external command, operable program or batch file.
+'cut' is not recognized as an internal or external command, operable program or batch file.
 ```
-
 The solution is to add `mingw_64/bin` directory to the user `PATH` environment variable.  See:
 https://discourse.mc-stan.org/t/errors-when-using-cmdstan-model/14984/21
 

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -136,8 +136,8 @@ for details on changing the `PATH`.
 
 __32-bit Builds__
 
-CmdStan defaults to a 64-bit build. On a 32-bit operating system,
-include `BIT=32` in CmdStan `make/local` file described in the next section.
+CmdStan defaults to a 64-bit build. On a 32-bit operating system, you must specify
+the make variable `BIT=32` as part of the `make` command, described in the next section.
 
 ## GNU-Make Utility {#gnu-make}
 
@@ -181,6 +181,21 @@ into a binary executable.
 For example, to compile the Stan program `my_program.stan` in directory `../my_dir/`,
 the make target is `../my_dir/my_program` or ` ../my_dir/my_program.exe` (on Windows).
 
+To call Make, you invoke the utility name, either `make` or `mingw32-make`, followed by, in order:
+
+- zero or more [Make program options](https://www.gnu.org/software/make/manual/html_node/Options-Summary.html), then specify any Make variables as a series of 
+
+- zero of more Make variables, described below
+
+- zero or more _target_ names; the set of names is determined by the Makefile rules.
+
+```
+make <flags> <variables> <targets>
+```
+
+
+__Makefile Variables__
+
 Make is invoked with a list of target names which can
 be preceded by zero or more Makefile variable name=value pairs.
 For example to compile `../my_dir/my_program.stan` for an OpenCL (GPU) machine,
@@ -190,8 +205,14 @@ the makefile variable `STAN_OPENCL` is set to `TRUE`:
 ```
 Makefile variables can also be set by creating a file named `local` in the
 CmdStan `make` subdirectory which contains a list of `<VARIABLE>=<VALUE>` pairs,
-one per line.  The complete set of Makefile variables can be found in file
-`cmdstan/stan/lib/stan_math/make/compiler_flags`.
+one per line.   For example, if you are working on a 32-bit machine,
+you would put the line `BIT=32` into the file `<cmdstan-home>/make/local`
+so that all CmdStan programs and Stan models compile properly.
+
+The complete set of Makefile variables can be found in file
+`<cmdstan-home>/cmdstan/stan/lib/stan_math/make/compiler_flags`.
+
+__Make Targets__
 
 When invoked without any arguments at all, Make prints a help message:
 ```

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -389,31 +389,32 @@ To do this, you must run the makefile commands from the `<cmdstan-home>` directo
 > make build
 ```
 
-### Common problems and how to resolve them
+### Common problems
 
-This section contains errors reported on https://discourse.mc-stan.org and the proposed solutions.
+This section contains solutions to problems reported on https://discourse.mc-stan.org
 
-- Problem:  model compilation fails, error message about PCH file, e.g.,
+**Compiler error message about PCH file**
+
+To speed up compilation, the Stan makefile pre-compiles parts of the core Stan library.
+If these pre-compiled files are out of sync with the compiled model, the compiler will complain, e.g.:
 
 ```
 error: PCH file uses an older PCH format that is no longer supported
 ```
 
-To speed up compilation, the Stan makefile pre-compiles parts of the core Stan library.
-This error message occurs when the compiler tries to use an out-of-date pre-compiled header file,
-(possibly found in a system cache). 
 In this case, clean and rebuild CmdStan, as shown in the previous section.
 
 
-#### Windows-specific errors
+**Windows: ‘mingw32-make’ is not recognised**
 
-- Problem: C++ toolchain installed, call to `mingw32-make` fails with error message:
+If the C++ toolchain has been installed but no properly registered,
+the call to `mingw32-make` will fail with the error message:
 
 ```
 ‘mingw32-make’ is not recognised as an internal or external command
 ```
 
-- Solution:  call utility `pacman`:
+The solution is to call utility `pacman` as follows:
 
 ```
 pacman -Sy mingw-w64-x86_64-make
@@ -422,14 +423,17 @@ pacman -Sy mingw-w64-x86_64-make
 See: https://discourse.mc-stan.org/t/cmdstan-installation-on-windows/11287/6
 
 
-- Problem: compilation fails with message:
+**Windows: compiler error message ‘cut’ is not recognized**
+
+The CmdStan makefile uses a few shell utilities which might not be present in Windows,
+resulting in the error message:
 
 ```
 ‘cut’ is not recognized as an internal or external command, operable program or batch file.
 ```
 
-- Solution:  add `mingw_64/bin` directory to the user `PATH` environment variable, discussion here:
-https://discourse.mc-stan.org/t/errors-when-using-cmdstan-model/14984/21?
+The solution is to add `mingw_64/bin` directory to the user `PATH` environment variable.  See:
+https://discourse.mc-stan.org/t/errors-when-using-cmdstan-model/14984/21
 
 
 [^1]:

--- a/src/cmdstan-guide/stansummary.Rmd
+++ b/src/cmdstan-guide/stansummary.Rmd
@@ -162,8 +162,14 @@ Options:
                               comma-separated integers from (1,99), inclusive.
                               Default is 5,50,95.
   -s, --sig_figs [n]          Significant figures reported. Default is 2.
-                              Must be an integer from (1, 10), inclusive.
+                              Must be an integer from (1, 18), inclusive.
 ```
 
 Both short an long option names are allowed.  Short names are specified as `-<o> <value>`;
 long option names can be specified either as `--<option>=<value>` or `--<option> <value>`.
+
+The amount of precision
+in the sampler output limits the amount of real precision in the summary report.
+CmdStan's command line interface also has output argument `sig_figs`.
+The default sampler output precision is 6.
+The `--sig_figs` argument to the stansummary program should not exceed the `sig_figs` argument to the sampler.

--- a/src/functions-reference/binary_distributions.Rmd
+++ b/src/functions-reference/binary_distributions.Rmd
@@ -35,34 +35,34 @@ dropping constant additive terms.
 \index{{\tt \bfseries bernoulli\_lpmf  }!{\tt (ints y \textbar\ reals theta): real}|hyperpage}
 
 `real` **`bernoulli_lpmf`**`(ints y | reals theta)`<br>\newline
-The log Bernoulli probability mass of y given chance of success theta
+The log Bernoulli probability mass of y given chance of success `theta`
 
 <!-- real; bernoulli_cdf; (ints y, reals theta); -->
 \index{{\tt \bfseries bernoulli\_cdf  }!{\tt (ints y, reals theta): real}|hyperpage}
 
 `real` **`bernoulli_cdf`**`(ints y, reals theta)`<br>\newline
 The Bernoulli cumulative distribution function of y given chance of
-success theta
+success `theta`
 
 <!-- real; bernoulli_lcdf; (ints y | reals theta); -->
 \index{{\tt \bfseries bernoulli\_lcdf  }!{\tt (ints y \textbar\ reals theta): real}|hyperpage}
 
 `real` **`bernoulli_lcdf`**`(ints y | reals theta)`<br>\newline
 The log of the Bernoulli cumulative distribution function of y given
-chance of success theta
+chance of success `theta`
 
 <!-- real; bernoulli_lccdf; (ints y | reals theta); -->
 \index{{\tt \bfseries bernoulli\_lccdf  }!{\tt (ints y \textbar\ reals theta): real}|hyperpage}
 
 `real` **`bernoulli_lccdf`**`(ints y | reals theta)`<br>\newline
 The log of the Bernoulli complementary cumulative distribution
-function of y given chance of success theta
+function of y given chance of success `theta`
 
 <!-- R; bernoulli_rng; (reals theta); -->
 \index{{\tt \bfseries bernoulli\_rng  }!{\tt (reals theta): R}|hyperpage}
 
 `R` **`bernoulli_rng`**`(reals theta)`<br>\newline
-Generate a Bernoulli variate with chance of success theta; may only be
+Generate a Bernoulli variate with chance of success `theta`; may only be
 used in transformed data and generated quantities blocks.
 For a description of argument and return types, see section
 [vectorized PRNG functions](#prng-vectorization).


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Updated CmdStan guide for addition of `sig_figs` output arg in 2.25.
Also added troubleshooting section to installation docs

Also added code font for arg `theta` for Bernoulli distress in Functions Reference because deemed not worth separate PR.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):   Columbia University




By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
