### PR TITLE
Added back html for ode docs (Issue #276)

### DIFF
--- a/src/functions-reference/deprecated_functions.Rmd
+++ b/src/functions-reference/deprecated_functions.Rmd
@@ -52,12 +52,14 @@ ODE.
 
 ### Non-Stiff Solver
 
+<!-- real[,]; integrate_ode_rk45; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); -->
   \index{{\tt \bfseries integrate\_ode\_rk45 }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, real[] theta, real[] x\_r, int[] x\_i): real[ , ]}|hyperpage}
 
 `real[ , ]` **`integrate_ode_rk45`**`(function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i)`<br>\newline
 Solves the ODE system for the times provided using the Dormand-Prince
 algorithm, a 4th/5th order Runge-Kutta method.
 
+<!-- real[,]; integrate_ode_rk45; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i, real rel_tol, real abs_tol, int max_num_steps); -->
   \index{{\tt \bfseries integrate\_ode\_rk45 }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, real[] theta, real[] x\_r, int[] x\_i, real rel\_tol, real abs\_tol, int max\_num\_steps): real[ , ]}|hyperpage}
 
 `real[ , ]` **`integrate_ode_rk45`**`(function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i, real rel_tol, real abs_tol, int max_num_steps)`<br>\newline
@@ -65,17 +67,20 @@ Solves the ODE system for the times provided using the Dormand-Prince
 algorithm, a 4th/5th order Runge-Kutta method with additional control
 parameters for the solver.
 
+<!-- real[,]; integrate_ode; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); -->
   \index{{\tt \bfseries integrate\_ode }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, real[] theta, real[] x\_r, int[] x\_i): real[ , ]}|hyperpage}
 
 `real[ , ]` **`integrate_ode`**`(function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i)`<br>\newline
 Solves the ODE system for the times provided using the Dormand-Prince
 algorithm, a 4th/5th order Runge-Kutta method.
 
+<!-- real[,]; integrate_ode_adams; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); -->
   \index{{\tt \bfseries integrate\_ode\_adams }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, real[] theta, data real[] x\_r, data int[] x\_i): real[ , ]}|hyperpage}
 
 `real[ , ]` **`integrate_ode_adams`**`(function ode, real[] initial_state, real initial_time, real[] times, real[] theta, data real[] x_r, data int[] x_i)`<br>\newline
 Solves the ODE system for the times provided using the Adams-Moulton method.
 
+<!-- real[,]; integrate_ode_adams; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i, real rel_tol, real abs_tol, int max_num_steps); -->
   \index{{\tt \bfseries integrate\_ode\_adams }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, real[] theta, data real[] x\_r, data int[] x\_i, data real rel\_tol, data real abs\_tol, data int max\_num\_steps): real[ , ]}|hyperpage}
 
 `real[ , ]` **`integrate_ode_adams`**`(function ode, real[] initial_state, real initial_time, real[] times, real[] theta, data real[] x_r, data int[] x_i, data real rel_tol, data real abs_tol, data int max_num_steps)`<br>\newline
@@ -84,12 +89,14 @@ method with additional control parameters for the solver.
 
 ### Stiff Solver
 
+<!-- real[,]; integrate_ode_bdf; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); -->
   \index{{\tt \bfseries integrate\_ode\_bdf }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, real[] theta, data real[] x\_r, data int[] x\_i): real[ , ]}|hyperpage}
 
 `real[ , ]` **`integrate_ode_bdf`**`(function ode, real[] initial_state, real initial_time, real[] times, real[] theta, data real[] x_r, data int[] x_i)`<br>\newline
 Solves the ODE system for the times provided using the backward differentiation
 formula (BDF) method.
 
+<!-- real[,]; integrate_ode_bdf; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i, real rel_tol, real abs_tol, int max_num_steps); -->
   \index{{\tt \bfseries integrate\_ode\_bdf }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, real[] theta, data real[] x\_r, data int[] x\_i, data real rel\_tol, data real abs\_tol, data int max\_num\_steps): real[ , ]}|hyperpage}
 
 `real[ , ]` **`integrate_ode_bdf`**`(function ode, real[] initial_state, real initial_time, real[] times, real[] theta, data real[] x_r, data int[] x_i, data real rel_tol, data real abs_tol, data int max_num_steps)`<br>\newline

--- a/src/functions-reference/higher-order_functions.Rmd
+++ b/src/functions-reference/higher-order_functions.Rmd
@@ -193,12 +193,14 @@ in the ODE solve function call must match the types of the arguments represented
 
 ### Non-Stiff Solver
 
+<!-- vector[]; ode_rk45; (function ode, vector initial_state, real initial_time, real[] times, ...); -->
 \index{{\tt \bfseries ode\_rk45 }!{\tt (function ode, real[] initial\_state, real initial\_time, real[] times, ...): vector[]}|hyperpage}
 
 `vector[]` **`ode_rk45`**`(function ode, vector initial_state, real initial_time, real[] times, ...)`<br>\newline
 Solves the ODE system for the times provided using the Dormand-Prince
 algorithm, a 4th/5th order Runge-Kutta method.
 
+<!-- vector[]; ode_rk45_tol; (function ode, vector initial_state, real initial_time, real[] times, real rel_tol, real abs_tol, int max_num_steps, ...); -->
 \index{{\tt \bfseries ode\_rk45\_tol }!{\tt (function ode, vector initial\_state, real initial\_time, real[] times, real rel\_tol, real abs\_tol, int max\_num\_steps, ...): vector[]}|hyperpage}
 
 `vector[]` **`ode_rk45_tol`**`(function ode, vector initial_state, real initial_time, real[] times, real rel_tol, real abs_tol, int max_num_steps, ...)`<br>\newline
@@ -206,11 +208,13 @@ Solves the ODE system for the times provided using the Dormand-Prince
 algorithm, a 4th/5th order Runge-Kutta method with additional control
 parameters for the solver.
 
+<!-- vector[]; ode_adams; (function ode, vector initial_state, real initial_time, real[] times, ...); -->
 \index{{\tt \bfseries ode\_adams }!{\tt (function ode, vector initial\_state, real initial\_time, real[] times, ...): vector[]}|hyperpage}
 
 `vector[]` **`ode_adams`**`(function ode, vector initial_state, real initial_time, real[] times, ...)`<br>\newline
 Solves the ODE system for the times provided using the Adams-Moulton method.
 
+<!-- vector[]; ode_adams_tol; (function ode, vector initial_state, real initial_time, real[] times, real rel_tol, real abs_tol, int max_num_steps, ...); -->
 \index{{\tt \bfseries ode\_adams\_tol }!{\tt (function ode, vector initial\_state, real initial\_time, real[] times, data real rel\_tol, data real abs\_tol, data int max\_num\_steps, ...): vector[]}|hyperpage}
 
 `vector[]` **`ode_adams_tol`**`(function ode, vector initial_state, real initial_time, real[] times, data real rel_tol, data real abs_tol, data int max_num_steps, ...)`<br>\newline
@@ -219,12 +223,14 @@ method with additional control parameters for the solver.
 
 ### Stiff Solver
 
+<!-- vector[]; ode_bdf; (function ode, vector initial_state, real initial_time, real[] times, ...); -->
 \index{{\tt \bfseries ode\_bdf }!{\tt (function ode, vector initial\_state, real initial\_time, real[] times, ...): vector[]}|hyperpage}
 
 `vector[]` **`ode_bdf`**`(function ode, vector initial_state, real initial_time, real[] times, ...)`<br>\newline
 Solves the ODE system for the times provided using the backward differentiation
 formula (BDF) method.
 
+<!-- vector[]; ode_bdf_tol; (function ode, vector initial_state, real initial_time, real[] times, real rel_tol, real abs_tol, int max_num_steps, ...); -->
 \index{{\tt \bfseries ode\_bdf\_tol }!{\tt (function ode, vector initial\_state, real initial\_time, real[] times, data real rel\_tol, data real abs\_tol, data int max\_num\_steps, ...): vector[]}|hyperpage}
 
 `vector[]` **`ode_bdf_tol`**`(function ode, vector initial_state, real initial_time, real[] times, data real rel_tol, data real abs_tol, data int max_num_steps, ...)`<br>\newline


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

I removed some html comments which turned out to be important for editors which do syntax stuff for Stan. Adding them back.

The output of `extract_function_sigs.py` looks like:

```
integrate_ode; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); real[,]
integrate_ode_adams; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); real[,]
integrate_ode_adams; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i, real rel_tol, real abs_tol, int max_num_steps); real[,]
integrate_ode_bdf; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); real[,]
integrate_ode_bdf; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i, real rel_tol, real abs_tol, int max_num_steps); real[,]
integrate_ode_rk45; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i); real[,]
integrate_ode_rk45; (function ode, real[] initial_state, real initial_time, real[] times, real[] theta, real[] x_r, int[] x_i, real rel_tol, real abs_tol, int max_num_steps); real[,]
```
```
ode_adams; (function ode, vector initial_state, real initial_time, real[] times, ...); vector[]
ode_adams_tol; (function ode, vector initial_state, real initial_time, real[] times, real rel_tol, real abs_tol, int max_num_steps, ...); vector[]
ode_bdf; (function ode, vector initial_state, real initial_time, real[] times, ...); vector[]
ode_bdf_tol; (function ode, vector initial_state, real initial_time, real[] times, real rel_tol, real abs_tol, int max_num_steps, ...); vector[]
ode_rk45; (function ode, vector initial_state, real initial_time, real[] times, ...); vector[]
ode_rk45_tol; (function ode, vector initial_state, real initial_time, real[] times, real rel_tol, real abs_tol, int max_num_steps, ...); vector[]
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
