### PR TITLE
Add docs for the discrete_range functions

### DIFF
--- a/src/functions-reference/bounded_discrete_distributions.Rmd
+++ b/src/functions-reference/bounded_discrete_distributions.Rmd
@@ -11,6 +11,7 @@ cat(' * <a href="beta-binomial-distribution.html">Beta-Binomial Distribution</a>
 cat(' * <a href="hypergeometric-distribution.html">Hypergeometric Distribution</a>\n')
 cat(' * <a href="categorical-distribution.html">Categorical Distribution</a>\n')
 cat(' * <a href="categorical-logit-glm.html">Categorical Logit generalized Linear Model (Softmax Regression)</a>\n')
+cat(' * <a href="discrete-range-distribution.html">Discrete Range Distribution</a>\n')
 cat(' * <a href="ordered-logistic-distribution.html">Ordered Logistic Distribution</a>\n')
 cat(' * <a href="ordered-logistic-glm.html">Ordered Logistic generalized Linear Model (Ordinal Regression)</a>\n')
 cat(' * <a href="ordered-probit-distribution.html">Ordered Probit Distribution</a>\n')
@@ -431,6 +432,71 @@ $1:N$ given $N$-vector of log-odds of outcomes `alpha + x * beta`.
 The log categorical probability mass function with outcomes `y` in
 $1:N$ given $N$-vector of log-odds of outcomes `alpha + x * beta`
 dropping constant additive terms.
+
+
+## Discrete range distribution {#discrete-range-distribution}
+
+### Probability mass functions
+
+If $l, u \in \mathbb{Z}$ are lower and upper bounds ($l \le u$), then for
+any integer $y \in \{l,\ldots,u\}$, \[ \text{DiscreteRange}(y ~|~ l, u) =
+\frac{1}{u - l + 1}. \]
+
+### Sampling statement
+
+`y ~ ` **`discrete_range`**`(l, u)`
+
+Increment the target log probability density with `discrete_range_lupmf(y | l, u)`
+dropping constant additive terms.
+<!-- real; discrete_range ~; -->
+\index{{\tt \bfseries discrete\_range }!sampling statement|hyperpage}
+
+### Stan functions
+
+All of the discrete range distributions are vectorized so that the
+outcome `y` and the bounds `l, u` can be a single integer (type `int`)
+or an array of integers (type `int[]`).
+
+<!-- real; discrete_range_lpmf; (ints y | ints l, ints u); -->
+\index{{\tt \bfseries discrete\_range\_lpmf }!{\tt (ints y \textbar\ ints l, ints u): real}|hyperpage}
+
+`real` **`discrete_range_lpmf`**`(ints y | ints l, ints u)`<br>\newline
+The log probability mass function with outcome(s) y in $l:u$.
+
+<!-- real; discrete_range_lupmf; (ints y | ints l, ints u); -->
+\index{{\tt \bfseries discrete\_range\_lupmf }!{\tt (ints y \textbar\ ints l, ints u): real}|hyperpage}
+
+`real` **`discrete_range_lupmf`**`(ints y | ints l, ints u)`<br>\newline
+The log probability mass function with outcome(s) y in $l:u$
+dropping constant additive terms.
+
+<!-- real; discrete_range_cdf; (ints y, ints l, ints u); -->
+\index{{\tt \bfseries discrete\_range\_cdf }!{\tt (ints n, ints N, reals theta): real}|hyperpage}
+
+`real` **`discrete_range_cdf`**`(ints y, ints l, ints u)`<br>\newline
+The discrete range cumulative distribution function
+for the given y, lower and upper bounds.
+
+<!-- real; discrete_range_lcdf; (ints y | ints l, ints u); -->
+\index{{\tt \bfseries discrete\_range\_lcdf }!{\tt (ints n \textbar\ ints N, reals theta): real}|hyperpage}
+
+`real` **`discrete_range_lcdf`**`(ints y | ints l, ints u)`<br>\newline
+The log of the discrete range cumulative distribution function
+for the given y, lower and upper bounds.
+
+<!-- real; discrete_range_lccdf; (ints y | ints l, ints u); -->
+\index{{\tt \bfseries discrete\_range\_lccdf }!{\tt (ints n \textbar\ ints N, reals theta): real}|hyperpage}
+
+`real` **`discrete_range_lccdf`**`(ints y | ints l, ints u)`<br>\newline
+The log of the discrete range complementary cumulative distribution function
+for the given y, lower and upper bounds.
+
+<!-- int; discrete_range_rng; (ints l, ints u); -->
+\index{{\tt \bfseries discrete\_range\_rng }!{\tt (ints l, ints u): int}|hyperpage}
+
+`int` **`discrete_range_rng`**`(ints l, ints u)`<br>\newline
+Generate a discrete variate between the given lower and upper bounds;
+may only be used in transformed data and generated quantities blocks
 
 
 ## Ordered logistic distribution

--- a/src/functions-reference/bounded_discrete_distributions.Rmd
+++ b/src/functions-reference/bounded_discrete_distributions.Rmd
@@ -496,7 +496,7 @@ for the given y, lower and upper bounds.
 
 `int` **`discrete_range_rng`**`(ints l, ints u)`<br>\newline
 Generate a discrete variate between the given lower and upper bounds;
-may only be used in transformed data and generated quantities blocks
+may only be used in transformed data and generated quantities blocks.
 
 
 ## Ordered logistic distribution


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary
Adds documentation for the `discrete_range` functions introduced by  stan-dev/math#1680 and stan-dev/math#1716. Fixes #147.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
