### PR TITLE
Typo in CmdStan Guide: history -> history_size

### DIFF
--- a/src/cmdstan-guide/optimize_config.Rmd
+++ b/src/cmdstan-guide/optimize_config.Rmd
@@ -90,7 +90,7 @@ or too small depending on the objective function and initialization.
 Being too big or too small just means that the first iteration will take longer
 (i.e., require more gradient evaluations) before the line search finds a good step length.
 
-In addition to the above, the L-BFGS algorithm has argument `history`
+In addition to the above, the L-BFGS algorithm has argument `history_size`
 which controls the size of the history it uses to approximate the Hessian.
 The value should be less than the dimensionality of the parameter space and,
 in general, relatively small values ($5$-$10$) are sufficient; the default value is $5$.


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix typo in CmdStan guide section describing L-BFGS arguments. I think the correct argument name is `history_size` not `history`. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
