### PR TITLE
Issue 298 add more docs

### DIFF
--- a/src/functions-reference/integer-valued_basic_functions.Rmd
+++ b/src/functions-reference/integer-valued_basic_functions.Rmd
@@ -8,6 +8,7 @@ if (knitr::is_html_output()) {
 cat(' * <a href="int-arithmetic.html">Integer-Valued Arithmetic Operators</a>\n')
 cat(' * <a href="absolute-functions.html">Absolute Functions</a>\n')
 cat(' * <a href="bound-functions.html">Bound Functions</a>\n')
+cat(' * <a href="bsize-functions.html">Size Functions</a>\n')
 }
 ```
 
@@ -126,7 +127,6 @@ absolute value of x
 
 `int` **`int_step`**`(int x)`<br>\newline
 
-
 <!-- int; int_step; (real x); -->
 \index{{\tt \bfseries int\_step }!{\tt (real x): int}|hyperpage}
 
@@ -154,4 +154,19 @@ Return the minimum of x and y. \[ \text{min}(x, y) = \begin{cases} x &
 `int` **`max`**`(int x, int y)`<br>\newline
 Return the maximum of x and y. \[ \text{max}(x, y) = \begin{cases} x &
 \text{if } x > y\\ y & \text{otherwise} \end{cases} \]
+
+## Size functions
+
+<!-- int; size; (int x); -->
+\index{{\tt \bfseries size }!{\tt (int x): int}|hyperpage}
+
+`int` **`size`**`(int x)`<br>\newline
+
+<!-- int; min; (real x); -->
+\index{{\tt \bfseries size }!{\tt (real x): int}|hyperpage}
+
+`int` **`size`**`(int x, int y)`<br>\newline
+
+Return the size of `x` which for scalar-valued `x` is 1.
+
 

--- a/src/functions-reference/integer-valued_basic_functions.Rmd
+++ b/src/functions-reference/integer-valued_basic_functions.Rmd
@@ -165,8 +165,8 @@ Return the maximum of x and y. \[ \text{max}(x, y) = \begin{cases} x &
 <!-- int; min; (real x); -->
 \index{{\tt \bfseries size }!{\tt (real x): int}|hyperpage}
 
-`int` **`size`**`(int x, int y)`<br>\newline
+`int` **`size`**`(real x)`<br>\newline
 
-Return the size of `x` which for scalar-valued `x` is 1.
+Return the size of `x` which for scalar-valued `x` is 1
 
 

--- a/src/functions-reference/integer-valued_basic_functions.Rmd
+++ b/src/functions-reference/integer-valued_basic_functions.Rmd
@@ -8,7 +8,7 @@ if (knitr::is_html_output()) {
 cat(' * <a href="int-arithmetic.html">Integer-Valued Arithmetic Operators</a>\n')
 cat(' * <a href="absolute-functions.html">Absolute Functions</a>\n')
 cat(' * <a href="bound-functions.html">Bound Functions</a>\n')
-cat(' * <a href="bsize-functions.html">Size Functions</a>\n')
+cat(' * <a href="size-functions.html">Size Functions</a>\n')
 }
 ```
 

--- a/src/functions-reference/matrix_operations.Rmd
+++ b/src/functions-reference/matrix_operations.Rmd
@@ -319,7 +319,35 @@ The result of dividing each entry in the row vector x by y
 `matrix` **`operator/`**`(matrix x, real y)`<br>\newline
 The result of dividing each entry in the matrix x by y
 
-### Elementwise arithmetic operations
+## Transposition operator
+
+Matrix transposition is represented using a postfix operator.
+
+<!-- matrix; operator'; (matrix x); -->
+\index{{\tt \bfseries operator\_transpose }!{\tt (matrix x): matrix}|hyperpage}
+
+`matrix` **`operator'`**`(matrix x)`<br>\newline
+The transpose of the matrix x, written as `x'`
+
+<!-- row_vector; operator'; (vector x); -->
+\index{{\tt \bfseries operator\_transpose }!{\tt (vector x): row\_vector}|hyperpage}
+
+`row_vector` **`operator'`**`(vector x)`<br>\newline
+The transpose of the vector x, written as `x'`
+
+<!-- vector; operator'; (row_vector x); -->
+\index{{\tt \bfseries operator\_transpose }!{\tt (row\_vector x): vector}|hyperpage}
+
+`vector` **`operator'`**`(row_vector x)`<br>\newline
+The transpose of the row vector x, written as `x'`
+
+## Elementwise functions
+
+Elementwise functions apply a function to each element of a vector or
+matrix, returning a result of the same shape as the argument.  There
+are many functions that are vectorized in addition to the ad hoc cases
+listed in this section; see section [function vectorization](#fun-vectorization) for the
+general cases.
 
 <!-- vector; operator.*; (vector x, vector y); -->
 \index{{\tt \bfseries operator\_elt\_multiply }!{\tt (vector x, vector y): vector}|hyperpage}
@@ -446,36 +474,6 @@ The elementwise power of y and x
 
 `matrix` **`operator.^`**`(real x, matrix y)`<br>\newline
 The elementwise power of y and x
-
-## Transposition operator
-
-Matrix transposition is represented using a postfix operator.
-
-<!-- matrix; operator'; (matrix x); -->
-\index{{\tt \bfseries operator\_transpose }!{\tt (matrix x): matrix}|hyperpage}
-
-`matrix` **`operator'`**`(matrix x)`<br>\newline
-The transpose of the matrix x, written as `x'`
-
-<!-- row_vector; operator'; (vector x); -->
-\index{{\tt \bfseries operator\_transpose }!{\tt (vector x): row\_vector}|hyperpage}
-
-`row_vector` **`operator'`**`(vector x)`<br>\newline
-The transpose of the vector x, written as `x'`
-
-<!-- vector; operator'; (row_vector x); -->
-\index{{\tt \bfseries operator\_transpose }!{\tt (row\_vector x): vector}|hyperpage}
-
-`vector` **`operator'`**`(row_vector x)`<br>\newline
-The transpose of the row vector x, written as `x'`
-
-## Elementwise functions
-
-Elementwise functions apply a function to each element of a vector or
-matrix, returning a result of the same shape as the argument.  There
-are many functions that are vectorized in addition to the ad hoc cases
-listed in this section;  see section [function vectorization](#fun-vectorization)for the
-general cases.
 
 ## Dot products and specialized products
 

--- a/src/functions-reference/matrix_operations.Rmd
+++ b/src/functions-reference/matrix_operations.Rmd
@@ -986,22 +986,22 @@ Create an identity matrix of size $k \times k$
 
 ## Container construction functions {#container-construction}
 
-<!-- real[]; linspaced_array; (int n, real lower, real upper); -->
-\index{{\tt \bfseries linspaced\_array }!{\tt (int n, real lower, real upper): real[]}|hyperpage}
+<!-- real[]; linspaced_array; (int n, data real lower, data real upper); -->
+\index{{\tt \bfseries linspaced\_array }!{\tt (int n, data real lower, data real upper): real[]}|hyperpage}
 
-`real[]` **`linspaced_array`**`(int n, real lower, real upper)`<br>\newline
+`real[]` **`linspaced_array`**`(int n, data real lower, data real upper)`<br>\newline
 Create a real array of length `n` of equidistantly-spaced elements between `lower` and `upper`
 
-<!-- vector; linspaced_vector; (int n, real lower, real upper); -->
-\index{{\tt \bfseries linspaced\_vector }!{\tt (int n, real lower, real upper): vector}|hyperpage}
+<!-- vector; linspaced_vector; (int n, data real lower, data real upper); -->
+\index{{\tt \bfseries linspaced\_vector }!{\tt (int n, data real lower, data real upper): vector}|hyperpage}
 
-`vector` **`linspaced_vector`**`(int n, real lower, real upper)`<br>\newline
+`vector` **`linspaced_vector`**`(int n, data real lower, data real upper)`<br>\newline
 Create an `n`-dimensional vector of equidistantly-spaced elements between `lower` and `upper`
 
-<!-- row_vector; linspaced_row_vector; (int n, real lower, real upper); -->
-\index{{\tt \bfseries linspaced\_row\_vector }!{\tt (int n, real lower, real upper): row\_vector}|hyperpage}
+<!-- row_vector; linspaced_row_vector; (int n, data real lower, data real upper); -->
+\index{{\tt \bfseries linspaced\_row\_vector }!{\tt (int n, data real lower, data real upper): row\_vector}|hyperpage}
 
-`row_vector` **`linspaced_row_vector`**`(int n, real lower, real upper)`<br>\newline
+`row_vector` **`linspaced_row_vector`**`(int n, data real lower, data real upper)`<br>\newline
 Create an `n`-dimensional row-vector of equidistantly-spaced elements between `lower` and `upper`
 
 <!-- int[]; one_hot_int_array; (int n, int k); -->

--- a/src/functions-reference/matrix_operations.Rmd
+++ b/src/functions-reference/matrix_operations.Rmd
@@ -10,6 +10,7 @@ cat(' * <a href="dot-products-and-specialized-products.html">Dot Products and Sp
 cat(' * <a href="reductions.html">Reductions</a>\n')
 cat(' * <a href="matrix-broadcast.html">Broadcast Functions</a>\n')
 cat(' * <a href="diagonal-matrix-functions.html">Diagonal Matrix Functions</a>\n')
+cat(' * <a href="container-construction.html">Container Construction Functions</a>\n')
 cat(' * <a href="slicing-and-blocking-functions.html">Slicing and Blocking Functions</a>\n')
 cat(' * <a href="matrix-concatenation.html">Matrix Concatenation</a>\n')
 cat(' * <a href="softmax.html">Special Matrix Functions</a>\n')
@@ -81,13 +82,13 @@ The number of columns in the matrix x
 \index{{\tt \bfseries size }!{\tt (vector x): int}|hyperpage}
 
 `int` **`size`**`(vector x)`<br>\newline
-The number of elements of `x`
+The size of `x`, i.e., the number of elements
 
 <!-- int; size; (row_vector x); -->
-\index{{\tt \bfseries size }!{\tt (row_vector x): int}|hyperpage}
+\index{{\tt \bfseries size }!{\tt (row\_vector x): int}|hyperpage}
 
 `int` **`size`**`(row_vector x)`<br>\newline
-The number of elements of `x`
+The size of `x`, i.e., the number of elements
 
 <!-- int; size; (matrix x); -->
 \index{{\tt \bfseries size }!{\tt (matrix x): int}|hyperpage}
@@ -974,6 +975,112 @@ is a vector, it is much more efficient to write `diag_post_multiply(m,
 v)` (and similarly for pre-multiplication). By the same token, it is
 better to use `quad_form_diag(m, v)` rather than `quad_form(m,
 diag_matrix(v))`.
+
+<!-- matrix; identity_matrix; (int k); -->
+\index{{\tt \bfseries identity\_matrix\_matrix }!{\tt (int k): matrix}|hyperpage}
+
+`matrix` **`identity_matrix`**`(int k)`<br>\newline
+Create an identity matrix of size $k \times k$
+
+
+
+## Container construction functions {#container-construction}
+
+<!-- real[]; linspaced_array; (int n, real lower, real upper); -->
+\index{{\tt \bfseries linspaced\_array }!{\tt (int n, real lower, real upper): real[]}|hyperpage}
+
+`real[]` **`linspaced_array`**`(int n, real lower, real upper)`<br>\newline
+Create a real array of length `n` of equidistantly-spaced elements between `lower` and `upper`
+
+<!-- vector; linspaced_vector; (int n, real lower, real upper); -->
+\index{{\tt \bfseries linspaced\_vector }!{\tt (int n, real lower, real upper): vector}|hyperpage}
+
+`vector` **`linspaced_vector`**`(int n, real lower, real upper)`<br>\newline
+Create an `n`-dimensional vector of equidistantly-spaced elements between `lower` and `upper`
+
+<!-- row_vector; linspaced_row_vector; (int n, real lower, real upper); -->
+\index{{\tt \bfseries linspaced\_row\_vector }!{\tt (int n, real lower, real upper): row\_vector}|hyperpage}
+
+`row_vector` **`linspaced_row_vector`**`(int n, real lower, real upper)`<br>\newline
+Create an `n`-dimensional row-vector of equidistantly-spaced elements between `lower` and `upper`
+
+<!-- int[]; one_hot_int_array; (int n, int k); -->
+\index{{\tt \bfseries one\_hot\_int\_array }!{\tt (int n, int k): int[]}|hyperpage}
+
+`int[]` **`one_hot_int_array`**`(int n, int k)`<br>\newline
+Create a one-hot encoded int array of length `n` with `array[k] = 1`
+
+<!-- real[]; one_hot_array; (int n, int k); -->
+\index{{\tt \bfseries one\_hot\_array }!{\tt (int n, int k): real[]}|hyperpage}
+
+`real[]` **`one_hot_array`**`(int n, int k)`<br>\newline
+Create a one-hot encoded real array of length `n` with `array[k] = 1`
+
+<!-- vector; one_hot_vector; (int K, int k); -->
+\index{{\tt \bfseries one\_hot\_vector }!{\tt (int n, int k): vector}|hyperpage}
+
+`vector` **`one_hot_vector`**`(int n, int k)`<br>\newline
+Create an `n`-dimensional one-hot encoded vector with `vector[k] = 1`
+
+<!-- row_vector; one_hot_row_vector; (int n, int k); -->
+\index{{\tt \bfseries one\_hot\_row\_vector }!{\tt (int n, int k): row\_vector}|hyperpage}
+
+`row_vector` **`one_hot_row_vector`**`(int n, int k)`<br>\newline
+Create an `n`-dimensional one-hot encoded row-vector  with `row_vector[k] = 1`
+
+<!-- int[]; ones_int_array; (int n); -->
+\index{{\tt \bfseries ones\_int\_array }!{\tt (int n): int[]}|hyperpage}
+
+`int[]` **`ones_int_array`**`(int n)`<br>\newline
+Create an int array of length `n` of all ones
+
+<!-- real[]; ones_array; (int n); -->
+\index{{\tt \bfseries ones\_array }!{\tt (int n): real[]}|hyperpage}
+
+`real[]` **`ones_array`**`(int n)`<br>\newline
+Create a real array of length `n` of all ones
+
+<!-- vector; ones_vector; (int n); -->
+\index{{\tt \bfseries ones\_vector }!{\tt (int n): vector}|hyperpage}
+
+`vector` **`ones_vector`**`(int n)`<br>\newline
+Create an `n`-dimensional vector of all ones
+
+<!-- row_vector; ones_row_vector; (int n); -->
+\index{{\tt \bfseries ones\_row\_vector }!{\tt (int n): row\_vector}|hyperpage}
+
+`row_vector` **`ones_row_vector`**`(int n)`<br>\newline
+Create an `n`-dimensional row-vector of all ones
+
+<!-- int[]; zeros_int_array; (int n); -->
+\index{{\tt \bfseries zeros\_int\_array }!{\tt (int n): int[]}|hyperpage}
+
+`int[]` **`zeros_int_array`**`(int n)`<br>\newline
+Create an int array of length `n` of all zeros
+
+<!-- real[]; zeros_array; (int n); -->
+\index{{\tt \bfseries zeros\_array }!{\tt (int n): real[]}|hyperpage}
+
+`real[]` **`zeros_array`**`(int n)`<br>\newline
+Create a real array of length `n` of all zeros
+
+<!-- vector; zeros_row_vector; (int n); -->
+\index{{\tt \bfseries zeros\_vector }!{\tt (int n): vector}|hyperpage}
+
+`vector` **`zeros_vector`**`(int n)`<br>\newline
+Create an `n`-dimensional vector of all zeros
+
+<!-- row_vector; zeros_row_vector; (int n); -->
+\index{{\tt \bfseries zeros\_row\_vector }!{\tt (int n): row\_vector}|hyperpage}
+
+`row_vector` **`zeros_row_vector`**`(int n)`<br>\newline
+Create an `n`-dimensional row-vector of all zeros
+
+<!-- vector; uniform_simplex; (int n); -->
+\index{{\tt \bfseries uniform\_simplex }!{\tt (int n): vector}|hyperpage}
+
+`vector` **`uniform_simplex`**`(int n)`<br>\newline
+Create an `n`-dimensional simplex with elements `vector[i] = 1 / n` for all $i \in 1, \dots, n$ 
 
 ## Slicing and blocking functions
 

--- a/src/functions-reference/matrix_operations.Rmd
+++ b/src/functions-reference/matrix_operations.Rmd
@@ -77,6 +77,25 @@ The number of columns in the row vector x
 `int` **`cols`**`(matrix x)`<br>\newline
 The number of columns in the matrix x
 
+<!-- int; size; (vector x); -->
+\index{{\tt \bfseries size }!{\tt (vector x): int}|hyperpage}
+
+`int` **`size`**`(vector x)`<br>\newline
+The number of elements of `x`
+
+<!-- int; size; (row_vector x); -->
+\index{{\tt \bfseries size }!{\tt (row_vector x): int}|hyperpage}
+
+`int` **`size`**`(row_vector x)`<br>\newline
+The number of elements of `x`
+
+<!-- int; size; (matrix x); -->
+\index{{\tt \bfseries size }!{\tt (matrix x): int}|hyperpage}
+
+`int` **`size`**`(matrix x)`<br>\newline
+The size of the matrix `x`.  For example, if `x` is a
+$5 \times 3$ matrix, then `size(x)` is 15
+
 ## Matrix arithmetic operators {#matrix-arithmetic-operators}
 
 Stan supports the basic matrix operations using infix, prefix and

--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -19,6 +19,7 @@ cat(' * <a href="link-functions.html">Link Functions</a>\n')
 cat(' * <a href="phi-function.html">Probability-Related Functions</a>\n')
 cat(' * <a href="betafun.html">Combinatorial Functions</a>\n')
 cat(' * <a href="composed-functions.html">Composed Functions</a>\n')
+cat(' * <a href="special-functions.html">Special Functions</a>\n')
 }
 ```
 
@@ -1474,3 +1475,19 @@ natural logarithm of the inverse logit function of x
 `R` **`log1m_inv_logit`**`(T x)`<br>\newline
 natural logarithm of 1 minus the inverse logit function of x
 
+
+
+## Special functions {$special-functions}
+
+<!-- R; lambert_w0; (reals x); -->
+\index{{\tt \bfseries lambert_w0 }!{\tt (T x): R}|hyperpage}
+
+`R` **`lambert_w0`**`(T x)`<br>\newline
+
+Implementation of the $W_0$ branch of the Lambert W function, i.e., solution to the function $W_0(x) \exp W_0(x) = x$
+
+<!-- R; lambert_wm1; (T x); -->
+\index{{\tt \bfseries lambert_wm1 }!{\tt (T x): R}|hyperpage}
+
+`R` **`lambert_wm1`**`(T x)`<br>\newline
+Implementation of the $W_{-1}$ branch of the Lambert W function, i.e., solution to the function $W_{-1}(x) \exp W_{-1}(x) = x$

--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -1475,19 +1475,17 @@ natural logarithm of the inverse logit function of x
 `R` **`log1m_inv_logit`**`(T x)`<br>\newline
 natural logarithm of 1 minus the inverse logit function of x
 
-
-
-## Special functions {$special-functions}
+## Special functions {#special-functions}
 
 <!-- R; lambert_w0; (reals x); -->
-\index{{\tt \bfseries lambert_w0 }!{\tt (T x): R}|hyperpage}
+\index{{\tt \bfseries lambert\_w0 }!{\tt (T x): R}|hyperpage}
 
 `R` **`lambert_w0`**`(T x)`<br>\newline
 
-Implementation of the $W_0$ branch of the Lambert W function, i.e., solution to the function $W_0(x) \exp W_0(x) = x$
+Implementation of the $W_0$ branch of the Lambert W function, i.e., solution to the function $W_0(x) \exp^{ W_0(x)} = x$
 
 <!-- R; lambert_wm1; (T x); -->
-\index{{\tt \bfseries lambert_wm1 }!{\tt (T x): R}|hyperpage}
+\index{{\tt \bfseries lambert\_wm1 }!{\tt (T x): R}|hyperpage}
 
 `R` **`lambert_wm1`**`(T x)`<br>\newline
-Implementation of the $W_{-1}$ branch of the Lambert W function, i.e., solution to the function $W_{-1}(x) \exp W_{-1}(x) = x$
+Implementation of the $W_{-1}$ branch of the Lambert W function, i.e., solution to the function $W_{-1}(x) \exp^{W_{-1}(x)} = x$

--- a/src/stan-users-guide/regression.Rmd
+++ b/src/stan-users-guide/regression.Rmd
@@ -399,10 +399,10 @@ model {
 }
 ```
 
-The prior on `beta` is coded in vectorized form.  As of Stan 2.18, the
-categorical-logit distribution is not vectorized for parameter
-arguments, so the loop is required.  The matrix multiplication is
-pulled out to define a local variable for all of the predictors for
+where `x_beta[n]'` is the transpose of `x_beta[n]`. The prior on `beta` is coded in vectorized form. 
+As of Stan 2.18, the categorical-logit distribution is not vectorized
+for parameter arguments, so the loop is required.  The matrix multiplication 
+is pulled out to define a local variable for all of the predictors for
 efficiency.  Like the Bernoulli-logit, the categorical-logit
 distribution applies softmax internally to convert an arbitrary vector
 to a simplex,


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Ciao all, in case you're interested, this PR fixes some issues mentioned in #298, such as:

- adds docu for overloads of `size()` under functions reference 2.4 for scalars and 5.1 for matrices and vectors #120
- adds docu for Lambert functions under a new category "3.15 Special functions" in real-valued basic functions #200 
- moves docu of elementwise operations for matrices/vectors from 5.2.4 to 5.4 #149 
- adds docu for container construction under a new category "5.9 Container construction functions" #206
- adds a sentence to explain transpose #167

Issue #196 is already solved and can imo be closed.

Cheers,
Simon
 
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simon Dirmeier



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
