### PR TITLE
Add docs for the skew double exponential

### DIFF
--- a/src/functions-reference/unbounded_continuous_distributions.Rmd
+++ b/src/functions-reference/unbounded_continuous_distributions.Rmd
@@ -14,6 +14,7 @@ cat(' * <a href="cauchy-distribution.html">Cauchy Distribution</a>\n')
 cat(' * <a href="double-exponential-laplace-distribution.html">Double Exponential (Laplace) Distribution</a>\n')
 cat(' * <a href="logistic-distribution.html">Logistic Distribution</a>\n')
 cat(' * <a href="gumbel-distribution.html">Gumbel Distribution</a>\n')
+cat(' * <a href="skew-double-exponential-distribution.html">Skew Double Exponential Distribution</a>\n')
 }
 ```
 
@@ -729,4 +730,68 @@ of y given location mu and scale beta
 Generate a gumbel variate with location mu and scale beta; may only be
 used in transformed data and generated quantities blocks. For a description
 of argument and return types, see section
+[vectorized PRNG functions](#prng-vectorization).
+
+## Skew double exponential distribution
+
+### Probability density function
+
+If $\mu \in \mathbb{R}$, $\sigma \in \mathbb{R}^+$ and $\tau \in [0, 1]$,
+then for $y \in \mathbb{R}$, 
+$$\begin{aligned} 
+& \text{SkewDoubleExponential}  (y|\mu,\sigma, \tau) = \\ 
+& \qquad \qquad \frac{2 \tau (1 - \tau) }{\sigma} \exp \left[ - \frac{2}{\sigma} \left[ \left(1 - \tau \right) I(y < \mu)  (\mu - y) + \tau I(y > \mu)(y-\mu)  \right]    \right]
+\end{aligned}$$
+
+
+### Sampling statement
+
+`y ~ ` **`skew_double_exponential`**`(mu, sigma, tau)`
+
+Increment target log probability density with `skew_double_exponential(y | mu, sigma, tau)`
+<!-- real; skew_double_exponential ~; -->
+\index{{\tt \bfseries skew\_double\_exponential }!sampling statement|hyperpage}
+
+### Stan functions
+
+<!-- real; skew_double_exponential_lpdf; (reals y | reals mu, reals sigma, reals tau); -->
+\index{{\tt \bfseries skew\_double\_exponential\_lpdf }!{\tt (reals y \textbar\ reals mu, reals sigma, reals tau): real}|hyperpage}
+
+`real` **`skew_double_exponential_lpdf`**`(reals y | reals mu, reals sigma, reals tau)`<br>\newline
+The log of the skew double exponential density of y given location mu, scale sigma and skewness tau
+
+<!-- real; skew_double_exponential_lupdf; (reals y | reals mu, reals sigma, reals tau); -->
+\index{{\tt \bfseries skew\_double\_exponential\_lupdf }!{\tt (reals y \textbar\ reals mu, reals sigma, reals tau): real}|hyperpage}
+
+`real` **`skew_double_exponential_lupdf`**`(reals y | reals mu, reals sigma, reals tau)`<br>\newline
+The log of the skew double exponential density of y given location mu, scale sigma and skewness tau dropping constant additive terms
+
+<!-- real; skew_double_exponential_cdf; (reals y, reals mu, reals sigma, reals tau); -->
+\index{{\tt \bfseries skew\_double\_exponential\_cdf }!{\tt (reals y, reals mu, reals sigma, reals tau): real}|hyperpage}
+
+`real` **`skew_double_exponential_cdf`**`(reals y, reals mu, reals sigma, reals tau)`<br>\newline
+The skew double exponential cumulative distribution function of y given
+location mu, scale sigma and skewness tau
+
+<!-- real; skew_double_exponential_lcdf; (reals y | reals mu, reals sigma, reals tau); -->
+\index{{\tt \bfseries skew\_double\_exponential\_lcdf }!{\tt (reals y \textbar\ reals mu, reals sigma, reals tau): real}|hyperpage}
+
+`real` **`skew_double_exponential_lcdf`**`(reals y | reals mu, reals sigma, reals tau)`<br>\newline
+The log of the skew double exponential cumulative distribution function of
+y given location mu, scale sigma and skewness tau
+
+<!-- real; skew_double_exponential_lccdf; (reals y | reals mu, reals sigma, reals tau); -->
+\index{{\tt \bfseries skew\_double\_exponential\_lccdf }!{\tt (reals y \textbar\ reals mu, reals sigma, reals tau): real}|hyperpage}
+
+`real` **`skew_double_exponential_lccdf`**`(reals y | reals mu, reals sigma, reals tau)`<br>\newline
+The log of the skew double exponential complementary cumulative
+distribution function of y given location mu, scale sigma and skewness tau
+
+<!-- R; skew_double_exponential_rng; (reals mu, reals sigma); -->
+\index{{\tt \bfseries skew\_double\_exponential\_rng }!{\tt (reals mu, reals sigma, reals tau): R}|hyperpage}
+
+`R` **`skew_double_exponential_rng`**`(reals mu, reals sigma, reals tau)`<br>\newline
+Generate a skew double exponential variate with location mu, scale
+sigma and skewness tau; may only be used in transformed data and generated quantities blocks. For a
+description of argument and return types, see section
 [vectorized PRNG functions](#prng-vectorization).


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR adds documentation for the skew double exponential distribution implemented [here](https://github.com/stan-dev/math/pull/2271). 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Simon Dirmeier

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
