### PR TITLE
higher-order_functions.Rmd typo fix

### DIFF
--- a/src/functions-reference/higher-order_functions.Rmd
+++ b/src/functions-reference/higher-order_functions.Rmd
@@ -427,7 +427,7 @@ f({ x1, x2, ... }) = g(x1) + g(x2) + ...
 ```
 
 Mathematically the summation reduction is associative and forming
-arbitrary partial sums in an aribitrary order will not change the
+arbitrary partial sums in an arbritrary order will not change the
 result. However, floating point numerics on computers only have
 a limited precision such that associativity does not hold
 exactly. This implies that the order of summation determines the exact


### PR DESCRIPTION
Found a typo inside reduce_sum docs

#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary

Found a small typo on  inside reduce_sum docs

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
