### PR TITLE
Fix marginalisation in the Dawid-Skene model

### DIFF
--- a/src/stan-users-guide/latent-discrete.Rmd
+++ b/src/stan-users-guide/latent-discrete.Rmd
@@ -929,9 +929,9 @@ This can be done item by item, with
 $$
 p(y \mid \theta, \pi) =
 \prod_{i=1}^I \sum_{k=1}^K
-  \left( \textsf{categorical}(z_i \mid \pi)
+  \left( \textsf{categorical}(k \mid \pi)
          \prod_{j=1}^J
-         \textsf{categorical}(y_{i, j} \mid \theta_{j, z[i]})
+         \textsf{categorical}(y_{i, j} \mid \theta_{j, k})
   \right).
 $$
 
@@ -945,9 +945,9 @@ probability function on the log scale,
 \begin{align*}
 \log p(y \mid \theta, \pi)
  &= \sum_{i=1}^I \log \left( \sum_{k=1}^K \exp
-    \left(\log \textsf{categorical}(z_i \mid \pi) \vphantom{\sum_{j=1}^J}\right.\right. 
+    \left(\log \textsf{categorical}(k \mid \pi) \vphantom{\sum_{j=1}^J}\right.\right. 
     \left.\left. + \ \sum_{j=1}^J
-           \log \textsf{categorical}(y_{i, j} \mid \theta_{j, z[i]})
+           \log \textsf{categorical}(y_{i, j} \mid \theta_{j, k})
     \right) \right),
 \end{align*}
 which can be directly coded using Stan's built-in `log_sum_exp`


### PR DESCRIPTION
The previous expressions included $z_i$ despite the fact that we are
marginalising it out.

Thanks to Lyle Gurrin for first pointing this out this to me.

#### Submission Checklist

- [X] Builds locally 
- [X] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Jeffrey Pullin

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
