### PR TITLE
Fix #356 - affine transform docs has the wrong direction of transform

### DIFF
--- a/src/reference-manual/transforms.Rmd
+++ b/src/reference-manual/transforms.Rmd
@@ -292,7 +292,7 @@ Stan uses an affine transform.  Such a variable $X$ is transformed to a new
 variable $Y$, where
 
 $$
-Y = \mu + \sigma * X.
+Y = \frac{X - \mu}{\sigma}.
 $$
 
 The default value for the offset $\mu$ is $0$ and for the multiplier $\sigma$ is
@@ -304,7 +304,7 @@ $1$ in case not both are specified.
 The inverse of this transform is
 
 $$
-X = \frac{Y-\mu}{\sigma}.
+X =  \mu + \sigma \cdot Y.
 $$
 
 ### Absolute derivative of the affine inverse transform
@@ -316,10 +316,10 @@ $$
 \left|
   \frac{d}{dy}
     \left(
-      \frac{y-\mu}{\sigma}
+      \mu + \sigma \cdot y
     \right)
   \right|
-= \frac{1}{\sigma}.
+= \sigma.
 $$
 
 Therefore, the density of the transformed variable $Y$ is
@@ -327,8 +327,8 @@ Therefore, the density of the transformed variable $Y$ is
 $$
 p_Y(y)
 =
- p_X \! \left( \frac{y-\mu}{\sigma} \right)
-    \cdot \frac{1}{\sigma}.
+ p_X \! \left( \mu + \sigma \cdot y \right)
+    \cdot \sigma.
 $$
 
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes #356 to show the correct direction of the affine transform when using `offset` or `multiplier`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Institute of Microbiology of the Czech Academy of Sciences

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
