### PR TITLE
Fix code in sparse ragged that prevents docs to build

### DIFF
--- a/src/stan-users-guide/sparse-ragged.Rmd
+++ b/src/stan-users-guide/sparse-ragged.Rmd
@@ -67,7 +67,7 @@ df <- read.table(text=
  3    | 2    | 0
 ", sep="|", header=TRUE, check.names=FALSE)
 kable(df, booktabs=TRUE, escape=FALSE, linesep="") %>%
-  kable_styling(full_width=FALSE)
+  kable_styling(full_width=TRUE)
 ```
 
 ```{r results="asis"}


### PR DESCRIPTION
#### Summary

Fixes the docs to build by setting full_width=TRUE for one of the Rmd tables. The tables rendered OK:


![image](https://user-images.githubusercontent.com/28476796/120697144-a9acea00-c4ad-11eb-9eae-8de14f388b84.png)


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
