### PR TITLE
Fix typo(?) in array broadcasting

### DIFF
--- a/src/functions-reference/array_operations.Rmd
+++ b/src/functions-reference/array_operations.Rmd
@@ -314,7 +314,7 @@ the vector `v`.
  vector[5] a[3];
  
  a = rep_array(v,3);  // fill a with copies of v
- a[2,4] = 9.0;        // v[4], a[1,4], a[2,4] unchanged
+ a[2,4] = 9.0;        // v[4], a[1,4], a[3,4] unchanged
 ```
 
 If the type T of x is itself an array type, then the result will be an


### PR DESCRIPTION
Given `a[2,4]` is being modified, I think the comment pertains to `a[3,4]` (i.e. all other copies of `v` have an unmodified 4th entry)

#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
