### PR TITLE
Remove grammar rules which only exist for error messaging

### DIFF
--- a/src/reference-manual/syntax.Rmd
+++ b/src/reference-manual/syntax.Rmd
@@ -31,6 +31,8 @@ The raw output is available [here](grammar.txt).
 
 <!-- This is the direct output of `obelisk -i parser.mly` 
      copied and pasted into reasonable section distinctions.
+     Additionally, items which exist only for error messaging
+     were removed, like allowing FUNCTIONBLOCK as a decl identifier
 -->
 ### Programs {-}
 
@@ -103,37 +105,6 @@ The raw output is available [here](grammar.txt).
                | ARRAY
 
 <decl_identifier> ::= <identifier>
-                    | FUNCTIONBLOCK
-                    | DATABLOCK
-                    | PARAMETERSBLOCK
-                    | MODELBLOCK
-                    | RETURN
-                    | IF
-                    | ELSE
-                    | WHILE
-                    | FOR
-                    | IN
-                    | BREAK
-                    | CONTINUE
-                    | VOID
-                    | INT
-                    | REAL
-                    | VECTOR
-                    | ROWVECTOR
-                    | MATRIX
-                    | ORDERED
-                    | POSITIVEORDERED
-                    | SIMPLEX
-                    | UNITVECTOR
-                    | CHOLESKYFACTORCORR
-                    | CHOLESKYFACTORCOV
-                    | CORRMATRIX
-                    | COVMATRIX
-                    | PRINT
-                    | REJECT
-                    | TARGET
-                    | GETLP
-                    | PROFILE
 
 <no_assign> ::= UNREACHABLE
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

A follow on to #384, this removes rules like allowing "functions" as an identifier which are rejected later in the compiler. These rules are in the parser because they allow easier error messaging than catching them at parse time, but they should not be used in the language specification.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
