### PR TITLE
Corrected range of arctan

### DIFF
--- a/src/functions-reference/atan_range
+++ b/src/functions-reference/atan_range
@@ -899,7 +899,7 @@ principal arc (inverse) sine (in radians) of x
 
 `R` **`atan`**`(T x)`<br>\newline
 principal arc (inverse) tangent (in radians) of x, with values from
-$-\pi$ to $\pi$
+$-\pi/2$ to $\pi/2$
 
 <!-- real; atan2; (real y, real x); -->
 \index{{\tt \bfseries atan2 }!{\tt (real y, real x): real}|hyperpage}


### PR DESCRIPTION
Range of atan is not -pi to pi, but -pi/2 to pi/2.

#### Submission Checklist

- [ ] Builds locally 
- [ ] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
