### PR TITLE
Update Cmdstan doc to remove stanc2 references

### DIFF
--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -240,7 +240,7 @@ CmdStan v2.23.0 help
     > make foo/bar
 
     This target will:
-    1. Install the Stan compiler (bin/stanc or bin/stanc2), as needed.
+    1. Install the Stan compiler (bin/stanc), as needed.
     2. Use the Stan compiler to generate C++ code, foo/bar.hpp.
     3. Compile the C++ code using cc . to generate foo/bar
 
@@ -252,7 +252,6 @@ CmdStan v2.23.0 help
     USER_HEADER: when STANCFLAGS has --allow_undefined, this is the name of the
       header file that is included. This defaults to "user_header.hpp" in the
       directory of the Stan program.
-    STANC2: When set, use bin/stanc2 to generate C++ code.
 
 
   Example - bernoulli model: examples/bernoulli/bernoulli.stan

--- a/src/cmdstan-guide/stanc.Rmd
+++ b/src/cmdstan-guide/stanc.Rmd
@@ -9,13 +9,6 @@ OCaml. This compiler is called "stanc3" and has has its own
 repository https://github.com/stan-dev/stanc3, from which pre-built
 binaries for Linux, Mac, and Windows can be downloaded.
 
-Prior to release 2.22, the Stan compiler program was compiled from C++
-source code that was part of the core Stan library. This C++ compiler
-is still available as program `bin/stanc2`. This compiler is no
-longer being maintained, i.e., existing bugs will not be fixed and new
-functions and features are only available in the stanc3 compiler. Its
-intended use is as a diagnostic tool and backup for the new stanc3 compiler.
-For some future version, it will be dropped from the release altogether.
 
 ## Instantiating the `stanc` binary
 
@@ -29,10 +22,7 @@ For Windows:
 ```
 make bin/stanc.exe
 ```
-To build the `bin/stanc2` program, specify:
-```
-make bin/stanc2
-```
+
 
 ## The Stan compiler program
 
@@ -88,11 +78,6 @@ override the default arguments to stanc, e.g.,
 ```
 > make STANCFLAGS="--include-paths=~/foo" examples/bernoulli/bernoulli
 ```
-To use the stanc2 compiler instead of the stanc3 compiler, set the
-make option `STANC2`:
-```
-> make STANC2=TRUE examples/bernoulli/bernoulli
-```
 
 ## Command-line options for stanc3
 
@@ -138,32 +123,12 @@ code. **WARNING:** _This is currently an experimental feature!_
 - `--warn-uninitialized` - Emit warnings about uninitialized variables
 to stderr. Currently an experimental feature.
 
+- `--warn-pedantic` - Emit warnings in [Pedantic mode](https://mc-stan.org/docs/reference-manual/pedantic-mode.html)
+which warns of potential issues in the meaning of your program.
 
 The compiler also provides a number of debug options which are
 primarily of interest to stanc3 developers; use the `--help`
 option to see the full set.
-
-## Command-line options for stanc2
-
-The stanc2 compiler has the same command-line syntax as the
-stanc3 compiler, but has fewer options:
-
-- `--help` - Displays the complete list of stanc3 options, then exits.
-
-- `--version` - Display stanc version number
-
-- `--name=<model_name>` - Specify the name of the class
-used for the implementation of the Stan model in the generated C++ code.
-
-- `--o=<file_name>` -  Specify the name of the file into
-which the generated C++ is written.
-
-- `--allow_undefined` - Do not throw a parser error
-if there is a function in the Stan program
-that is declared but not defined in the functions block.
-
-- `--include_paths=<dir1,...dirN>` - Takes a comma-separated list
-of directories that may contain a file in an `#include` directive.
 
 ## Using external C++ code
 

--- a/src/cmdstan-guide/stanc.Rmd
+++ b/src/cmdstan-guide/stanc.Rmd
@@ -95,6 +95,9 @@ The stanc3 options are:
 
 - `--version` - Display stanc version number
 
+- `--info` - Print information about the model, such
+as the type information for variables and the list of used distributions.
+
 - `--name=<model_name>` - Specify the name of the class
 used for the implementation of the Stan model in the generated C++ code.
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Resolves #389 
Resolves #372 

This removes references to stanc2 from the cmdstan guide, as it is no longer shipped. It also adds two new flags to the list of stanc options, `--info` and `--warn-pedantic`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
