### PR TITLE
Update reserved words section to allow C++ keywords

### DIFF
--- a/src/reference-manual/expressions.Rmd
+++ b/src/reference-manual/expressions.Rmd
@@ -141,7 +141,7 @@ the tokens are reserved for future use.
 
 ```
 for, in, while, repeat, until, if, then, else,
-true, false, target, struct, typedef, export, 
+true, false, target, struct, typedef, export,
 auto, extern, var, static
 ```
 
@@ -160,6 +160,7 @@ cannot be used as variable names:
 
 ```
 print, reject, profile, get_lp, increment_log_prob,
+target
 ```
 
 The following block identifiers are reserved and cannot be used as variable names:
@@ -188,18 +189,19 @@ conflict.
 #### Reserved names backend languages {-}
 
 Stan primarily generates code in C++, which features its own
-reserved words. It **is legal** to name a variable any of the
-following names, _but_ this will lead to it being renamed `_stan_NAME`
-(e.g. `_stan_public`) in the generated C++ code. 
+reserved words. It is legal to name a variable any of the
+following names, however doing so will lead to it being renamed
+`_stan_NAME` (e.g. `_stan_public`) behind the scenes (in the
+generated C++ code).
 
 <!-- corresponds to the list in stanc3/src/stan_math_backend/Transform_Mir.ml -->
 ```
 alignas, alignof, and, and_eq, asm, bitand, bitor, bool,
 case, catch, char, char16_t, char32_t, class, compl, const,
-constexpr, const_cast, decltype, default, delete, do, 
+constexpr, const_cast, decltype, default, delete, do,
 double, dynamic_cast, enum, explicit, float, friend, goto,
 inline, long, mutable, namespace, new, noexcept, not, not_eq,
-nullptr, operator, or, or_eq, private, protected, public, 
+nullptr, operator, or, or_eq, private, protected, public,
 register, reinterpret_cast, short, signed, sizeof,
 static_assert, static_cast, switch, template, this, thread_local,
 throw, try, typeid, typename, union, unsigned, using, virtual,
@@ -403,7 +405,7 @@ If an array expression contains only integer elements, such as
 legal.
 
 ```stan
-array[2] real a = { -3, 12 };  
+array[2] real a = { -3, 12 };
 // error: array [] real can't be assigned to array [] real
 ```
 
@@ -1174,10 +1176,10 @@ differential equations in Stan:
 
 ```stan
 functions {
-  array [] real foo(real t, 
-                    array [] real y, 
-                    array [] real theta, 
-                    array [] real x_r, 
+  array [] real foo(real t,
+                    array [] real y,
+                    array [] real theta,
+                    array [] real x_r,
                     array [] real x_i) {
     // ...
   }
@@ -1191,7 +1193,7 @@ array[1] real theta;
 array[0] real x_r;
 array[0] int x_i;
 // ...
-array[T, 2] real y_hat = integrate_ode_rk45(foo, y0, t0, 
+array[T, 2] real y_hat = integrate_ode_rk45(foo, y0, t0,
                                               ts, theta, x_r, x_i);
 ```
 
@@ -1218,7 +1220,7 @@ differential equations in Stan:
 
 ```stan
 functions {
-  vector foo(real t, vector y, real theta, vector beta, 
+  vector foo(real t, vector y, real theta, vector beta,
             array [] real x_i, int index) {
     // ...
   }
@@ -1233,7 +1235,7 @@ vector[7] beta;
 array[10] int x_i;
 int index;
 // ...
-vector[2] y_hat[T] = ode_rk45(foo, y0, t0, ts, theta, 
+vector[2] y_hat[T] = ode_rk45(foo, y0, t0, ts, theta,
                               beta, x_i, index);
 ```
 

--- a/src/reference-manual/expressions.Rmd
+++ b/src/reference-manual/expressions.Rmd
@@ -141,17 +141,25 @@ the tokens are reserved for future use.
 
 ```
 for, in, while, repeat, until, if, then, else,
-true, false, target
+true, false, target, struct, typedef, export, 
+auto, extern, var, static
 ```
 
 Variables should not be named after types, either, and thus may not be
 any of the following.
 
 ```
-int, real, vector, simplex, unit_vector, ordered,
-positive_ordered, row_vector, matrix,
+int, real, complex, vector, simplex, unit_vector,
+ordered, positive_ordered, row_vector, matrix,
 cholesky_factor_corr, cholesky_factor_cov,
 corr_matrix, cov_matrix
+```
+
+The following built in functions are also reserved and
+cannot be used as variable names:
+
+```
+print, reject, profile, get_lp, increment_log_prob,
 ```
 
 The following block identifiers are reserved and cannot be used as variable names:
@@ -161,15 +169,6 @@ functions, model, data, parameters, quantities,
 transformed, generated
 ```
 
-#### Reserved names from Stan implementation {-}
-
-Some variable names are reserved because they are used within
-Stan's C++ implementation.  These are
-
-```
-var, fvar, STAN_MAJOR, STAN_MINOR, STAN_PATCH,
-STAN_MATH_MAJOR, STAN_MATH_MINOR, STAN_MATH_PATCH
-```
 
 
 #### Reserved distribution names {-}
@@ -186,25 +185,28 @@ to halt and report the name and location of the variable causing the
 conflict.
 
 
-#### Reserved names from C++ {-}
+#### Reserved names backend languages {-}
 
-Finally, variable names, including the names of models, should not
-conflict with any of the C++ keywords.
+Stan primarily generates code in C++, which features its own
+reserved words. It **is legal** to name a variable any of the
+following names, _but_ this will lead to it being renamed `_stan_NAME`
+(e.g. `_stan_public`) in the generated C++ code. 
 
+<!-- corresponds to the list in stanc3/src/stan_math_backend/Transform_Mir.ml -->
 ```
-alignas, alignof, and, and_eq, asm, auto, bitand, bitor, bool,
-break, case, catch, char, char16_t, char32_t, class, compl,
-const, constexpr, const_cast, continue, decltype, default,
-delete, do, double, dynamic_cast, else, enum, explicit,
-export, extern, false, float, for, friend, goto, if,
-inline, int, long, mutable, namespace, new, noexcept,
-not, not_eq, nullptr, operator, or, or_eq, private,
-protected, public, register, reinterpret_cast, return,
-short, signed, sizeof, static, static_assert, static_cast,
-struct, switch, template, this, thread_local, throw, true,
-try, typedef, typeid, typename, union, unsigned, using,
-virtual, void, volatile, wchar_t, while, xor, xor_eq
+alignas, alignof, and, and_eq, asm, bitand, bitor, bool,
+case, catch, char, char16_t, char32_t, class, compl, const,
+constexpr, const_cast, decltype, default, delete, do, 
+double, dynamic_cast, enum, explicit, float, friend, goto,
+inline, long, mutable, namespace, new, noexcept, not, not_eq,
+nullptr, operator, or, or_eq, private, protected, public, 
+register, reinterpret_cast, short, signed, sizeof,
+static_assert, static_cast, switch, template, this, thread_local,
+throw, try, typeid, typename, union, unsigned, using, virtual,
+volatile, wchar_t, xor, xor_eq, fvar, STAN_MAJOR, STAN_MINOR,
+STAN_PATCH, STAN_MATH_MAJOR, STAN_MATH_MINOR, STAN_MATH_PATCH
 ```
+<!-- mention python here when TFP backend finished -->
 
 ### Legal characters {-}
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

This is the docs for https://github.com/stan-dev/stanc3/pull/962. It reorganizes the reserved words section to add a few that were not previously mentioned (`print`, for example) and document the behavior that PR will introduce re: C++ reserved words. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
