### PR TITLE
Add conda install instructions to the cmdstan guide

### DIFF
--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -25,6 +25,11 @@ to activate the CmdStan makefile from anywhere. To enable either
 of these, ensure your environment is activated (via
 `conda activate cmdstan`, or whichever name you used above).
 
+Issues with the conda installation are handled separately.
+Please report conda-specific problems
+[here](https://github.com/conda-forge/cmdstan-feedstock/issues).
+
+
 ## Source installation
 
 To install CmdStan from source you need:

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -8,10 +8,10 @@ will install a pre-built version of CmdStan along with the required
 dependencies (i.e. a C++ compiler, a version of Make, and required
 libraries) detailed below under [Source installation].
 
-One can create a new conda environment (named `stan`)
+One can create a new conda environment (named `stan-env`)
 and install CmdStan with the following command.
 ```
-conda create -n stan -c conda-forge cmdstan
+conda create -n stan-env -c conda-forge cmdstan
 ```
 or install it in an existing environment with
 ```
@@ -27,8 +27,20 @@ Installing software directly in `base` is not recommended by conda, but may be
 appropriate for some users who do not intend to use multiple environments]
 with `conda activate <env>`, where `<env>` is the name of
 the environment CmdStan was installed into. In the first command
-above, the environment was named `stan`, but any name may be used
-so long as it you are consistent.
+above, the environment was named `stan-env`, but any name may be used
+so long as you are consistent.
+
+You can check which version of CmdStan is installed in your current
+environment by running the following command.
+```
+conda list cmdstan
+```
+Finally, you can specify a different version for installation by adding `=VERSION`
+to the end of the above commands.^[You can view available versions with the
+command `conda search -c conda-forge cmdstan`] For example,
+```
+conda install -c conda-forge cmdstan=2.27.0
+```
 
 Please report conda-specific install problems directly to the
 conda-forge issue tracker,

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -8,25 +8,30 @@ will install a pre-built version of CmdStan along with the required
 dependencies (i.e. a C++ compiler, a version of Make, and required
 libraries) detailed below under [Source installation].
 
-One can create a new conda environment and install CmdStan with
-the following command.
-
+One can create a new conda environment (named `stan`)
+and install CmdStan with the following command.
 ```
-conda create -n cmdstan -c conda-forge cmdstan
+conda create -n stan -c conda-forge cmdstan
 ```
 or install it in an existing environment with
 ```
 conda install -c conda-forge cmdstan
 ```
 
-With the conda installation, one can use the R or Python
-bindings to CmdStan, or can use the command `cmdstan_model`
-to activate the CmdStan makefile from anywhere. To enable either
-of these, ensure your environment is activated (via
-`conda activate cmdstan`, or whichever name you used above).
+The conda installation is designed so one can use the R or Python
+bindings to CmdStan seamlessly. Additionally, it provides the command
+`cmdstan_model` to activate the CmdStan makefile from anywhere.
+To enable either of these, ensure your environment is activated^[A special
+environment, called `base`, is activated automatically by conda on startup.
+Installing software directly in `base` is not recommended by conda, but may be
+appropriate for some users who do not intend to use multiple environments]
+with `conda activate <env>`, where `<env>` is the name of
+the environment CmdStan was installed into. In the first command
+above, the environment was named `stan`, but any name may be used
+so long as it you are consistent.
 
-Issues with the conda installation are handled separately.
-Please report conda-specific problems
+Please report conda-specific install problems directly to the
+conda-forge issue tracker,
 [here](https://github.com/conda-forge/cmdstan-feedstock/issues).
 
 

--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -1,6 +1,33 @@
 # CmdStan Installation
 
-To install CmdStan you need:
+## Installation via `conda`
+
+CmdStan can be installed via the package management system [conda](https://docs.conda.io/en/latest/)
+via the [conda-forge channel](https://conda-forge.org/). This
+will install a pre-built version of CmdStan along with the required
+dependencies (i.e. a C++ compiler, a version of Make, and required
+libraries) detailed below under [Source installation].
+
+One can create a new conda environment and install CmdStan with
+the following command.
+
+```
+conda create -n cmdstan -c conda-forge cmdstan
+```
+or install it in an existing environment with
+```
+conda install -c conda-forge cmdstan
+```
+
+With the conda installation, one can use the R or Python
+bindings to CmdStan, or can use the command `cmdstan_model`
+to activate the CmdStan makefile from anywhere. To enable either
+of these, ensure your environment is activated (via
+`conda activate cmdstan`, or whichever name you used above).
+
+## Source installation
+
+To install CmdStan from source you need:
 
 - A modern C++11 compiler.  [Supported versions](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms#supported-cpp-versions-and-compilers) are
     + Linux: g++ 4.9.3 or clang 6.0
@@ -24,12 +51,12 @@ Cloning CmdStan from GitHub creates a directory simply called `cmdstan`.
 Throughout this manual, we refer to this top-level CmdStan source directory as **`<cmdstan-home>`**.
 
 
-## Installing the C++ toolchain
+### Installing the C++ toolchain
 
 The C++ toolchain consists of a modern C++ compiler and the GNU-Make utility,
 described in greater detail in the following section.
 
-### Linux:  `g++` and `make`
+#### Linux:  `g++` and `make`
 
 
 On Linux, the C++ compiler command `g++` and the GNU-Make command is `make`.
@@ -58,7 +85,7 @@ sudo apt install make
 If you can't run `sudo`, you will need to ask your sysadmin
 or cluster administrator to install these tools for you.
 
-### MacOS:  `clang++` and `make`
+#### MacOS:  `clang++` and `make`
 
 To install a C++ development
 environment on a Mac, use Apple's Xcode development environment
@@ -94,7 +121,7 @@ CmdStan requires g++ at 4.9.3 or later.  Trying to install later versions of g++
 or `macports` is no longer recommended; use the XCode toolchain.
 
 
-### Windows:  `g++` and `mingw32-make`  {#windows-make}
+#### Windows:  `g++` and `mingw32-make`  {#windows-make}
 
 The Windows toolchain consists of programs `g++`, the C++ compiler,
 and `mingw32-make`, the GNU-Make utility.
@@ -139,7 +166,7 @@ __32-bit Builds__
 CmdStan defaults to a 64-bit build. On a 32-bit operating system, you must specify
 the make variable `BIT=32` as part of the `make` command, described in the next section.
 
-## GNU-Make utility {#gnu-make}
+### GNU-Make utility {#gnu-make}
 
 CmdStan relies on the GNU-make utility to build both the
 Stan model executables and the CmdStan tools.
@@ -147,7 +174,7 @@ Stan model executables and the CmdStan tools.
 GNU-Make builds executable programs and libraries from source code by reading files
 called Makefiles which specify how to derive the target program.
 A Makefile consists of a set of recursive rules where each rule
-specifies a target, its dependencies, 
+specifies a target, its dependencies,
 and the specific operations required to build the target.
 Specifying dependencies for a target provides a way to control
 the build process so that targets which depend on other files will
@@ -183,7 +210,7 @@ the make target is `../my_dir/my_program` or ` ../my_dir/my_program.exe` (on Win
 
 To call Make, you invoke the utility name, either `make` or `mingw32-make`, followed by, in order:
 
-- zero or more [Make program options](https://www.gnu.org/software/make/manual/html_node/Options-Summary.html), then specify any Make variables as a series of 
+- zero or more [Make program options](https://www.gnu.org/software/make/manual/html_node/Options-Summary.html), then specify any Make variables as a series of
 
 - zero of more Make variables, described below
 
@@ -229,7 +256,7 @@ CmdStan v2.23.0 help
     4. Build the diagnose utility bin/diagnose
     5. Build all libraries and object files compile and link an executable Stan program
 
-    Note: to build using multiple cores, use the -j option to make, e.g., 
+    Note: to build using multiple cores, use the -j option to make, e.g.,
     for 4 cores:
     > make build -j4
 
@@ -272,7 +299,7 @@ CmdStan v2.23.0 help
 --------------------------------------------------------------------------------
 ```
 
-## Clone the GitHub CmdStan repository {#git-clone.section}
+### Clone the GitHub CmdStan repository {#git-clone.section}
 
 This section can be skipped if you want to build CmdStan using the release tarfile,
 which contains all source files an libraries needed to build CmdStan.
@@ -305,7 +332,7 @@ The resulting set of directories should have the same structure as the release:
 - directory `cmdstan/stan` contains the sub-module `stan` (https://github.com/stan-dev/stan)
 - directory `cmdstan/stan/lib/stan_math` contains the sub-module `math` (https://github.com/stan-dev/math)
 
-## Building CmdStan
+### Building CmdStan
 
 Building CmdStan involves preparing a set of executable programs
 and compiling the command line interface and supporting libraries.
@@ -381,7 +408,10 @@ absolute path to the Intel TBB library when linking into Stan programs.)
 ## Checking the Stan compiler
 
 To check that the CmdStan installation is complete
-and in working order, run the following series of commands on Linux/macOS:
+and in working order, run the following series of commands
+from the folder which CmdStan was installed.
+
+On Linux/macOS:
 
 ```
 # compile the example
@@ -398,11 +428,11 @@ and in working order, run the following series of commands on Linux/macOS:
 > bin/stansummary output.csv
 ```
 
-On Windows run the following:
+On Windows:
 
 ```
 # compile the example
-> mingw32-make examples/bernoulli/bernoulli.exe 
+> mingw32-make examples/bernoulli/bernoulli.exe
 
 # fit to provided data (results of 10 trials, 2 out of 10 successes)
 > ./examples/bernoulli/bernoulli.exe sample data file=examples/bernoulli/bernoulli.data.json


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds instructions for how to install cmdstan via the [conda-forge distribution](https://github.com/conda-forge/cmdstan-feedstock). I'm not sure if we want this in the main doc or not, but we have it as the recommended way for [cmdstanpy](https://cmdstanpy.readthedocs.io/en/v0.9.77/installation.html#conda-users-recommended)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
