### PR TITLE
Align notation for the correlation matrix transform

### DIFF
--- a/src/reference-manual/transforms.Rmd
+++ b/src/reference-manual/transforms.Rmd
@@ -738,7 +738,7 @@ transformed via the bijective function $\tanh : \mathbb{R} \rightarrow
 (-1, 1)$
 
 $$
-\tanh x = \frac{\exp(2x) - 1}{\exp(2x) + 1}.
+\tanh y = \frac{\exp(2y) - 1}{\exp(2y) + 1}.
 $$
 
 Then, define a $K \times K$ matrix $z$, the upper triangular values of
@@ -880,7 +880,7 @@ The final stage of the transform reverses the hyperbolic tangent
 transform, which is defined by
 
 $$
-\tanh^{-1} v = \frac{1}{2} \log \left( \frac{1 + v}{1 - v} \right).
+y = \tanh^{-1} z = \frac{1}{2} \log \left( \frac{1 + z}{1 - z} \right).
 $$
 
 The inverse hyperbolic tangent function, $\tanh^{-1}$, is also called


### PR DESCRIPTION
Fixes

1. 10.9 -- 'Correlation matrix inverse transform' talks about the unconstrained values `y`, but uses `x` in the displayed equation.
1. 10.9 -- 'Correlation matrix transform' uses the as yet undefined variable `v`, but should use `z` and note that `y = arctanh(z)`.

#### Submission Checklist

- [ ] Builds locally 
- [ ] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
