### PR TITLE
Add docs on num_chains, num_threads

### DIFF
--- a/src/cmdstan-guide/mcmc_sampling_intro.Rmd
+++ b/src/cmdstan-guide/mcmc_sampling_intro.Rmd
@@ -127,8 +127,8 @@ available:
 If the model uses within-chain parallelization (`map_rect` or `reduce_sum` calls), the threads are automatically
 scheduled to run the parallel parts of a single chain or run the sequential parts of another chains. The below
 call starts 4 chains that can use 16 threads. At a given moment a single chain may use all 16 threads,
-1 thread, anything in between, or can wait for a thread to be available. The scheduling is left to the Threading
-Building Blocks scheduler.
+1 thread, anything in between, or can wait for a thread to be available. The scheduling is left to the [Threading
+Building Blocks scheduler](https://software.intel.com/content/www/us/en/develop/documentation/tbb-documentation/top/intel-threading-building-blocks-developer-guide/the-task-scheduler/how-task-scheduling-works.html).
 
 ```
 ./bernoulli_par sample num_chains=4 data file=bernoulli.data.json output file=output.csv num_threads=16

--- a/src/cmdstan-guide/mcmc_sampling_intro.Rmd
+++ b/src/cmdstan-guide/mcmc_sampling_intro.Rmd
@@ -104,7 +104,7 @@ recommended when using the NUTS sampling algorithm with either the diagonal (`di
 
 ### Using the num_chains argument to run multiple chains
 
-The `num_chains` argument can be used with the NUTS sampling algorihtm with either the diagonal (`diag_e`) on dense
+The `num_chains` argument can be used with the NUTS sampling algorihtm with either the diagonal (`diag_e`) or dense
 (`dense_e`) metric.
 
 Example that will run 4 chains:

--- a/src/cmdstan-guide/mcmc_sampling_intro.Rmd
+++ b/src/cmdstan-guide/mcmc_sampling_intro.Rmd
@@ -89,7 +89,7 @@ Finally, the sampler reports timing information:
                0.024 seconds (Total)
 ```
 
-## Running multiple chains
+## Running multiple chains {#multi-chain-sampling}
 
 A Markov chain generates samples from the target distribution only after it has converged to equilibrium.
 In theory, convergence is only guaranteed asymptotically as the number of draws grows without bound.
@@ -98,8 +98,46 @@ One way to monitor whether a chain has converged to the equilibrium distribution
 to other randomly initialized chains.
 For robust diagnostics, we recommend running 4 chains.
 
+There are two different ways of running multiple chains, with the `num_chains` argument using a single executable
+and by using the Unix and DOS shell to run multiple executables. The former is currently supported and 
+recommended when using the NUTS sampling algorithm with either the diagonal (`diag_e`) on dense (`dense_e`) metric.
+
+### Using the num_chains argument to run multiple chains
+
+The `num_chains` argument can be used with the NUTS sampling algorihtm with either the diagonal (`diag_e`) on dense
+(`dense_e`) metric.
+
+Example that will run 4 chains:
+```
+./bernoulli sample num_chains=4 data file=bernoulli.data.json output file=output.csv
+```
+
+If the model was not compiled with `STAN_THREADS=true`, the above command will run 4 chains sequentially and will
+produce the sample in `output_1.csv`, `output_2.csv`, `output_3.csv`, `output_4.csv`. A suffix with the chain id
+is appended to the provided output filename (`output.csv` in the above command).
+
+If the model was compiled with `STAN_THREADS=true`, the chains can run in parallel, with the `num_threads` argument
+defining the maximum number of threads used to run the chains. If the model uses no within-chain parallelization
+(`map_rect` or `reduce_sum` calls), the below command will run 4 chains in parallel, provided there are cores
+available:
+```
+./bernoulli sample num_chains=4 data file=bernoulli.data.json output file=output.csv num_threads=4
+```
+
+If the model uses within-chain parallelization (`map_rect` or `reduce_sum` calls), the threads are automatically
+scheduled to run the parallel parts of a single chain or run the sequential parts of another chains. The below
+call starts 4 chains that can use 16 threads. At a given moment a single chain may use all 16 threads,
+1 thread, anything in between, or can wait for a thread to be available. The scheduling is left to the Threading
+Building Blocks scheduler.
+
+```
+./bernoulli_par sample num_chains=4 data file=bernoulli.data.json output file=output.csv num_threads=16
+```
+
+### Using shell for running multiple chains
+
 To run multiple chains given a model and data, either sequentially or in parallel,
-we use the Unix or DOS shell `for` loop to set up index variables needed to identify
+we can also use the Unix or DOS shell `for` loop to set up index variables needed to identify
 each chain and its outputs.
 
 On MacOS or Linux, the [for-loop syntax](https://linuxcourse.rutgers.edu/documents/Bash-Beginners-Guide/sect_09_01.html)

--- a/src/cmdstan-guide/parallelization.Rmd
+++ b/src/cmdstan-guide/parallelization.Rmd
@@ -33,23 +33,27 @@ make path/to/model
 ### Running
 
 Before running a multi-threaded model, we need to specify the maximum number of threads
-a single chain can use. This is done by setting the environment variable
-`STAN_NUM_THREADS`. On Unix systems we can set it using the `export` command. The 
-following would set the maximum number of threads to use for a chain to four:
+the program can run (total threads for all chains). This is done by setting the `num_threads`
+argument. Valid values for `num_threads` are positive integers and -1. If `num_threads` is set 
+to -1, all available cores will be used.
+
+Generally, this number should not exceed the number of available cores for best performance.
+
+Example:
+
 ```
-export STAN_NUM_THREADS=4
-```
-In Windows PowerShell use the following command:
-```
-Set-Variable -Name STAN_NUM_THREADS -Value "4"
+./model sample data file=data.json num_threads=4 ...
 ```
 
-Generally, this number should not exceed the number of available cores.
-If this variable isn't set, then the program will run with only one thread.
+When the model is compiled with `STAN_THREADS` we can sample with multiple chains with a single
+executable (see section [running multiple chains]{#multi-chain-sampling} for cases when this is
+available). When running multiple chains `num_threads` is the maximum number of threads that can
+be used by all the chains combined. The exact number of threads that will be used for each chain
+at a given point in time is determined by the TBB scheduler. The following example start 2 chains
+with 8 total threads available:
 
-Once `STAN_NUM_THREADS` is set, run a model as normal:
 ```
-./model sample data file=data.json ...
+./model sample num_chains=2 data file=data.json num_threads=8 ...
 ```
 
 ## Multi-processing with MPI


### PR DESCRIPTION
#### Summary

Fixes #405 

Adds missing docs for num_chains and num_threads to the parallelization section as well as running multiple chains.
No rush for reviewing but would be great to get it in for the release (looking like 4th October right now).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
