### PR TITLE
Add includes to external function example

### DIFF
--- a/src/cmdstan-guide/external_code.Rmd
+++ b/src/cmdstan-guide/external_code.Rmd
@@ -42,6 +42,9 @@ this program to C++, but the generated C++ code will not compile
 unless you write a file
 such as `examples/bernoulli/make_odds.hpp` with the following lines
 ```
+#include <boost/math/tools/promotion.hpp>
+#include <ostream>
+
 namespace bernoulli_model_namespace {
           template <typename T0__>  inline  typename
           boost::math::tools::promote_args<T0__>::type  make_odds(const T0__&


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

The CmdStan external functions example is missing some `include` directives it needs to compile. This resolves that

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
