### PR TITLE
single-statements to blocks in canonicalizer

### DIFF
--- a/src/stan-users-guide/using-stanc.Rmd
+++ b/src/stan-users-guide/using-stanc.Rmd
@@ -662,7 +662,25 @@ Some of the changes made are:
 
 * Replacing `increment_log_prob` calls with `target+=` statements
 
+* Replacing single-statement branches with blocks.
 
+  For example, the following statement
+
+  ```stan
+  if (cond)
+    #result
+  ```
+
+  will be formatted as follows
+  
+  ```stan
+  if (cond) {
+    #result
+  }
+  ```
+  
+  and similarly for For/While loops containing a single statement.
+  
 ### Known issues
 
 The formatting and canonicalizing features of stanc3 are still under


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [ ] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary
Canonicalizer now adds brackets around single statements in if-else/for/while (https://github.com/stan-dev/stanc3/pull/1003)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Adam Haber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
