### PR TITLE
add docs for bernoulli_logit_glm_rng

### DIFF
--- a/src/functions-reference/binary_distributions.Rmd
+++ b/src/functions-reference/binary_distributions.Rmd
@@ -264,3 +264,22 @@ The log Bernoulli probability mass of y given chance of success
 The log Bernoulli probability mass of y given chance of success
 `inv_logit(alpha + x * beta)` dropping constant additive terms.
 `r since("2.25")`
+
+<!-- array[] int; bernoulli_logit_glm_rng; (matrix x, vector alpha, vector beta); -->
+\index{{\tt \bfseries bernoulli\_logit\_glm\_rng  }!{\tt (matrix x, vector alpha, vector beta): array[] int}|hyperpage}
+
+`array[] int` **`bernoulli_logit_glm_rng`**`(matrix x, vector alpha, vector beta)`<br>\newline
+Generate an array of Bernoulli variates with chances of success
+`inv_logit(alpha + x * beta)`; may only be used in transformed data and generated
+quantities blocks.
+`r since("2.29")`
+
+
+<!-- array[] int; bernoulli_logit_glm_rng; (row_vector x, vector alpha, vector beta); -->
+\index{{\tt \bfseries bernoulli\_logit\_glm\_rng  }!{\tt (row\_vector x, vector alpha, vector beta): array[] int}|hyperpage}
+
+`array[] int` **`bernoulli_logit_glm_rng`**`(row_vector x, vector alpha, vector beta)`<br>\newline
+Generate an array of Bernoulli variates with chances of success
+`inv_logit(alpha + x * beta)`; may only be used in transformed data and generated
+quantities blocks.
+`r since("2.29")`


### PR DESCRIPTION
Docs for https://github.com/stan-dev/stanc3/pull/1034 .
Regarding `since("VERSION")` - should this be 2.29 or 2.28?

#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary
Add documentation for `bernoulli_logit_glm_rng` functions .

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Adam Haber

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
