### PR TITLE
Replace `twiddle` with `tilde`

### DIFF
--- a/src/stan-users-guide/using-stanc.Rmd
+++ b/src/stan-users-guide/using-stanc.Rmd
@@ -231,8 +231,8 @@ in more detail in following sections):
     constants are used as distribution arguments.
 -   *Control flow depends on a parameter.* Branching control flow (like if/else)
     depends on a parameter value .
--   *Parameter has multiple twiddles.* A parameter is on the left-hand side of
-    multiple twiddles.
+-   *Parameter has multiple tildes.* A parameter is on the left-hand side of
+    multiple tildes.
 -   *Parameter has zero or multiple priors.* A parameter has zero or more than
     one prior distribution.
 -   *Variable is used before assignment.* A variable is used before being
@@ -443,7 +443,7 @@ Warning at 'param-dep-cf-warn.stan', line 19, column 2 to line 21, column 3:
 ```
 
 
-### Parameters with multiple twiddles
+### Parameters with multiple tildes
 
 A warning is generated when a parameter is found on the left-hand side of more than one ~ statements (or an equivalent `target +=` conditional density statement). This pattern is not inherently an issue, but it is unusual and may indicate a mistake.
 
@@ -470,8 +470,8 @@ model {
 Pedantic mode produces the following warning.
 
 ```
-Warning at 'multi-twiddle.stan', line 9, column 2 to column 19:
-  The parameter a is on the left-hand side of more than one twiddle
+Warning at 'multi-tildes.stan', line 9, column 2 to column 19:
+  The parameter a is on the left-hand side of more than one tildes
   statement.
 ```
 


### PR DESCRIPTION
#### Summary

In pedantic mode docs, we use the word twiddle instead of tilde. I know they are considered synonyms, but given that we used tilde everywhere else (parser, docs, etc), it should be tilde here as well.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Rok Češnovar



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
