### PR TITLE
automatically detect stan version numbers in function_sigs script

### DIFF
--- a/extract_function_sigs.py
+++ b/extract_function_sigs.py
@@ -8,7 +8,9 @@ import os
 import os.path
 import sys
 import contextlib
-
+from lxml import html
+import requests
+import re
 
 @contextlib.contextmanager
 def pushd(new_dir):
@@ -23,8 +25,16 @@ def main():
         stan_major = int(sys.argv[1])
         stan_minor = int(sys.argv[2])
     else:
-        print('Expecting 2 arguments <MAJOR> <MINOR> version numbers')
-        sys.exit(1)
+        page = requests.get('https://mc-stan.org/docs/functions-reference/index.html')
+        if page.status_code == 404:
+            print('Stan version not found! Add 2 arguments <MAJOR> <MINOR> version numbers')
+            sys.exit(1)
+            
+        tree = html.fromstring(page.content)  
+        stan_url = tree.xpath('/html/body/a/@href')
+        x = re.findall(r'[0-9]+', stan_url[0])
+        stan_major = int(x[0])
+        stan_minor = int(x[1])
 
     sigs = set()
     ref_dir = os.path.join('src', 'functions-reference')

--- a/extract_function_sigs.py
+++ b/extract_function_sigs.py
@@ -29,7 +29,7 @@ def main():
             git_hash = subprocess.run(bash_git_hash, stdout=subprocess.PIPE, universal_newlines=True).stdout
             outfile_name = 'stan-functions-{}.txt'.format(str(git_hash).strip())
         except OSError:
-            print('Stan version not found! Add 2 arguments <MAJOR> <MINOR> version numbers')
+            print('Stan version not found and Git not found! Either install Git or add 2 arguments <MAJOR> <MINOR> version numbers')
             sys.exit(1)
 
     sigs = set()


### PR DESCRIPTION
#### Summary

I got tired of putting in the Stan major and minor versions for the extract_function_sigs.py script. This looks at the index URL and extracts those from the redirecting link.

#### Copyright and Licensing

Sean Pinkey



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
