### PR TITLE
Add missing docs for ordered_probit_lpmf signatures

### DIFF
--- a/src/functions-reference/bounded_discrete_distributions.Rmd
+++ b/src/functions-reference/bounded_discrete_distributions.Rmd
@@ -741,6 +741,20 @@ The log ordered probit probability mass of k given linear predictors
 eta, and cutpoints c dropping constant additive terms.
 `r since("2.25")`
 
+<!-- real; ordered_probit_lpmf; (ints k | real eta, vectors c); -->
+\index{{\tt \bfseries ordered\_probit\_lpmf }!{\tt (ints k \textbar\ real eta, vectors c): real}|hyperpage}
+
+`real` **`ordered_probit_lpmf`**`(ints k | real eta, vectors c)`<br>\newline
+The log ordered probit probability mass of k given linear predictor eta, and cutpoints c.
+`r since("2.19")`
+
+<!-- real; ordered_probit_lupmf; (ints k | real eta, vectors c); -->
+\index{{\tt \bfseries ordered\_probit\_lupmf }!{\tt (ints k \textbar\ real eta, vectors c): real}|hyperpage}
+
+`real` **`ordered_probit_lupmf`**`(ints k | real eta, vectors c)`<br>\newline
+The log ordered probit probability mass of k given linear predictor eta, and cutpoints c dropping constant additive terms.
+`r since("2.19")`
+
 <!-- int; ordered_probit_rng; (real eta, vector c); -->
 \index{{\tt \bfseries ordered\_probit\_rng }!{\tt (real eta, vector c): int}|hyperpage}
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds docs for: 

```
  ordered_probit_lpmf(array[] int, real, vector) => real
  ordered_probit_lpmf(array[] int, real, array[] vector) => real
```

These 2 signatures have been supported since 2.19, although I am not sure if their inclusion was completely intentional. They do work though (eta is broadcasted).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Rok Češnovar



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
