### PR TITLE
linspaced int array returns array of ints

### DIFF
--- a/src/functions-reference/matrix_operations.Rmd
+++ b/src/functions-reference/matrix_operations.Rmd
@@ -1181,7 +1181,7 @@ Create a real array of length `n` of equidistantly-spaced elements between `lowe
 <!-- array[] real; linspaced_int_array; (int n, int lower, int upper); -->
 \index{{\tt \bfseries linspaced\_int\_array }!{\tt (int n, int lower, int upper): array[] real}|hyperpage}
 
-`array[] real` **`linspaced_int_array`**`(int n, int lower, int upper)`<br>\newline
+`array[] int` **`linspaced_int_array`**`(int n, int lower, int upper)`<br>\newline
 Create a regularly spaced, increasing integer array of length `n` between `lower` and `upper`, inclusively.
 If `(upper - lower) / (n - 1)` is less than one, repeat each output `(n - 1) / (upper - lower)` times.
 If neither `(upper - lower) / (n - 1)` or `(n - 1) / (upper - lower)` are integers, `upper` is reduced until one of these is true.


### PR DESCRIPTION
The docs show `linspaced_int_array` returning an array of reals. This fixes that to say an array of ints.

https://mc-stan.org/docs/2_28/functions-reference/container-construction.html