### PR TITLE
Document lvalue multi-indexing deprecation

### DIFF
--- a/src/reference-manual/deprecations.Rmd
+++ b/src/reference-manual/deprecations.Rmd
@@ -247,6 +247,24 @@ in the language in the specified version.
 | multiplier | 2.32    |
 
 
+## Nested multiple indexing in assignments
+
+Stan interprets nested indexing in assingments as flat indexing so that a statement like
+```stan
+a[:][1] = b;
+```
+is the same as
+```stan
+a[:,1] = b;
+```
+However, this is inconsistent with
+[multiple indexing rules](https://mc-stan.org/docs/reference-manual/language-multi-indexing.html).
+To avoid confusion nested multiple indexing in assignment will be an error after Stan 2.32.
+Nesting single indexing is still allowed as it cannot lead to ambiguity.
+
+*Scheduled Removal*: Stan 2.32
+
+
 ## Deprecated Functions
 
 Several built-in Stan functions have been deprecated. Consult the


### PR DESCRIPTION
#### Submission Checklist

- [ ] Builds locally 
- [ ] New functions marked with `` `r since("VERSION")` ``
- [X] Declare copyright holder and open-source license: see below

#### Summary

Multiple indexing in lvalues is buggy, deprecate it.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Niko Huurre

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
