### PR TITLE
Build with syntax highlighting from pandoc

### DIFF
--- a/src/cmdstan-guide/_output.yml
+++ b/src/cmdstan-guide/_output.yml
@@ -1,6 +1,7 @@
 bookdown::gitbook:
   code folding: hide
   css: stan-manual.css
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   split_by: "chapter"
   config:
     search:
@@ -24,5 +25,6 @@ bookdown::gitbook:
 subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   includes:
     in_header: header.tex

--- a/src/functions-reference/_output.yml
+++ b/src/functions-reference/_output.yml
@@ -1,6 +1,7 @@
 bookdown::gitbook:
   css: ../stan-manual.css
   split_by: "section"
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   config:
     search:
         engine: lunr
@@ -22,7 +23,7 @@ bookdown::gitbook:
 subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   includes:
     in_header: header.tex
     after_body: postamble.tex
-

--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -1068,7 +1068,7 @@ complementary error function of x
 `r since("2.0, vectorized in 2.13")`
 
 <!-- R; inv_erfc; (T x); -->
-\index{{\tt \bfseries inv_erfc }!{\tt (T x): R}|hyperpage}
+\index{{\tt \bfseries inv\_erfc }!{\tt (T x): R}|hyperpage}
 
 `R` **`inv_erfc`**`(T x)`<br>\newline
 inverse of the complementary error function of x

--- a/src/reference-manual/_output.yml
+++ b/src/reference-manual/_output.yml
@@ -1,6 +1,7 @@
 bookdown::gitbook:
   css: ../stan-manual.css
   split_by: "section"
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   config:
     search:
         engine: lunr
@@ -23,5 +24,6 @@ bookdown::gitbook:
 subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   includes:
     in_header: header.tex

--- a/src/stan-users-guide/_output.yml
+++ b/src/stan-users-guide/_output.yml
@@ -2,6 +2,7 @@ bookdown::gitbook:
   code folding: hide
   css: stan-manual.css
   split_by: "section"
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   config:
     search:
         engine: lunr
@@ -24,5 +25,6 @@ bookdown::gitbook:
 subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
+  pandoc_args: ["--syntax-definition","../stan.xml"]
   includes:
     in_header: header.tex

--- a/src/stan.xml
+++ b/src/stan.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE language SYSTEM "language.dtd">
+<language name="Stan"
+          section="Scientific"
+          version="4"
+          kateversion="5.0"
+          indenter="cstyle"
+          extensions="*.stan;*.stanfuncs"
+          license="MIT">
+  <highlighting>
+    <list name="controlflow">
+      <item>break</item>
+      <item>continue</item>
+      <item>else</item>
+      <item>for</item>
+      <item>if</item>
+      <item>in</item>
+      <item>return</item>
+      <item>while</item>
+    </list>
+    <list name="keywords">
+      <item>reject</item>
+      <item>print</item>
+      <item>integrate_ode</item>
+      <item>integrate_ode_bdf</item>
+      <item>integrate_ode_rk45</item>
+      <item>algebra_solver</item>
+    </list>
+    <list name="types">
+      <item>int</item>
+      <item>real</item>
+      <item>vector</item>
+      <item>ordered</item>
+      <item>positive_ordered</item>
+      <item>simplex</item>
+      <item>unit_vector</item>
+      <item>row_vector</item>
+      <item>matrix</item>
+      <item>cholesky_factor_corr</item>
+      <item>cholesky_factor_cov</item>
+      <item>corr_matrix</item>
+      <item>cov_matrix</item>
+      <item>void</item>
+    </list>
+    <contexts>
+      <context attribute="Normal Text" lineEndContext="#stay" name="Normal">
+        <DetectSpaces />
+        <DetectChar attribute="Comment" context="Hash comment" char="#"/>
+        <Detect2Chars attribute="Comment" context="C-style comment" char="/" char1="/"/>
+        <Detect2Chars attribute="Comment" context="Block comment" char="/" char1="*" beginRegion="Comment"/>
+        <RegExpr attribute="Keyword" context="#stay" String="\btarget\s*\+=" />
+        <DetectChar attribute="Operator" context="After less-than" char="&lt;" />
+        <DetectChar attribute="Punctuation" context="After comma" char="," />
+        <DetectChar attribute="Operator" context="After Right Paren" char=")" />
+        <RegExpr attribute="Keyword" context="#stay" String="\b(functions|(transformed\s+)?(data|parameters)|model|generated\s+quantities)\b" />
+        <keyword attribute="Control Flow" context="#stay" String="controlflow" />
+        <keyword attribute="Keyword" context="#stay" String="keywords" />
+        <keyword attribute="Data Type" context="#stay" String="types" />
+        <RegExpr attribute="Identifier" context="#stay" String="[A-Za-z][A-Za-z0-9_]*" />
+        <Float attribute="Real" />
+        <Int attribute="Int" />
+        <DetectChar attribute="Punctuation" context="#stay" char="{" beginRegion="Brace1" />
+        <DetectChar attribute="Punctuation" context="#stay" char="}" endRegion="Brace1" />
+        <DetectChar attribute="String" context="String" char="&quot;" />
+        <RegExpr attribute="Assignment" context="#stay" String="([+-]?=|\.?[*/]=)" />
+        <RegExpr attribute="Operator" context="#stay" String="(:|\?|\|\||&amp;&amp;|==|!=|&lt;=?|&gt;=?|\+|-|\.?\*|\.?/|%|\\|'|^)" />
+        <RegExpr attribute="Punctuation" context="#stay" String="[[\]()]" />
+      </context>
+      <context attribute="String" lineEndContext="#stay" name="String">
+        <DetectChar attribute="String" context="#pop" char="&quot;"/>
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="Hash comment">
+        <DetectSpaces />
+        <IncludeRules context="##Comments" />
+      </context>
+      <context attribute="Comment" lineEndContext="#pop" name="C-style comment">
+        <DetectSpaces />
+        <IncludeRules context="##Comments" />
+      </context>
+      <context attribute="Comment" lineEndContext="#stay" name="Block comment">
+        <DetectSpaces />
+        <Detect2Chars attribute="Comment" context="#pop" char="*" char1="/" endRegion="Comment"/>
+        <WordDetect attribute="Doc Tag" String="@return" context="#stay" />
+        <WordDetect attribute="Doc Tag" String="@param" context="#stay" />
+        <IncludeRules context="##Comments" />
+      </context>
+      <context attribute="Normal Text" name="After comma" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop" >
+        <DetectSpaces />
+        <RegExpr context="Upper Bound" String="upper\s*=" lookAhead="true" />
+      </context>
+      <context attribute="Normal Text" name="After less-than" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop" >
+        <DetectSpaces />
+        <RegExpr context="Upper Bound" String="upper\s*=" lookAhead="true" />
+        <RegExpr context="Lower Bound" String="lower\s*=" lookAhead="true" />
+      </context>
+      <context attribute="Normal Text" name="After Right Paren" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop" >
+        <DetectSpaces />
+        <RegExpr context="Truncation" String="T\s*\[" lookAhead="true" />
+      </context>
+      <context attribute="Normal Text" name="Upper Bound" lineEndContext="#stay" >
+        <StringDetect attribute="Keyword" String="upper" context="#stay" />
+        <DetectChar attribute="Punctuation" char="=" context="#pop" />
+      </context>
+      <context attribute="Normal Text" name="Lower Bound" lineEndContext="#stay" >
+        <StringDetect attribute="Keyword" String="lower" context="#stay" />
+        <DetectChar attribute="Punctuation" char="=" context="#pop" />
+      </context>
+      <context attribute="Normal Text" name="Truncation" lineEndContext="#stay" >
+        <DetectChar attribute="Keyword" char="T" context="#stay" />
+        <DetectChar attribute="Punctuation" char="[" context="#pop" />
+      </context>
+    </contexts>
+    <itemDatas>
+      <itemData name="Normal Text"  defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Control Flow" defStyleNum="dsControlFlow" spellChecking="false"/>
+      <itemData name="Keyword"      defStyleNum="dsKeyword" spellChecking="false"/>
+      <itemData name="Data Type"    defStyleNum="dsDataType" spellChecking="false"/>
+      <itemData name="Int"          defStyleNum="dsDecVal" spellChecking="false"/>
+      <itemData name="Real"         defStyleNum="dsFloat" spellChecking="false"/>
+      <itemData name="String"       defStyleNum="dsString"/>
+      <itemData name="Comment"      defStyleNum="dsComment"/>
+      <itemData name="Assignment"   defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Operator"     defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Punctuation"  defStyleNum="dsNormal" spellChecking="false"/>
+      <itemData name="Identifier"   defStyleNum="dsNormal" spellChecking="false" />
+      <itemData name="Doc Tag"      defStyleNum="dsAnnotation" spellChecking="false" />
+    </itemDatas>
+  </highlighting>
+  <general>
+    <comments>
+      <comment name="singleLine" start="//" />
+      <comment name="multiLine" start="/*" end="*/" region="Comment" />
+    </comments>
+    <keywords casesensitive="1" />
+  </general>
+</language>
+<!-- kate: replace-tabs on; tab-width 2; indent-width 2; -->

--- a/src/stan.xml
+++ b/src/stan.xml
@@ -5,7 +5,7 @@
           version="4"
           kateversion="5.0"
           indenter="cstyle"
-          extensions="*.stan;*.stanfuncs"
+          extensions="*.stan;*.stanfunctions"
           license="MIT">
   <highlighting>
     <list name="controlflow">
@@ -17,6 +17,7 @@
       <item>in</item>
       <item>return</item>
       <item>while</item>
+      <item>profile</item>
     </list>
     <list name="keywords">
       <item>reject</item>
@@ -27,15 +28,21 @@
       <item>algebra_solver</item>
     </list>
     <list name="types">
+      <item>lower</item>
+      <item>upper</item>
+      <item>offset</item>
+      <item>multiplier</item>
       <item>int</item>
       <item>real</item>
       <item>vector</item>
+      <item>complex</item>
       <item>ordered</item>
       <item>positive_ordered</item>
       <item>simplex</item>
       <item>unit_vector</item>
       <item>row_vector</item>
       <item>matrix</item>
+      <item>array</item>
       <item>cholesky_factor_corr</item>
       <item>cholesky_factor_cov</item>
       <item>corr_matrix</item>
@@ -57,6 +64,7 @@
         <keyword attribute="Keyword" context="#stay" String="keywords" />
         <keyword attribute="Data Type" context="#stay" String="types" />
         <RegExpr attribute="Identifier" context="#stay" String="[A-Za-z][A-Za-z0-9_]*" />
+        <RegExpr context="#stay" attribute="Complex" String="(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?i" />
         <Float attribute="Real" />
         <Int attribute="Int" />
         <DetectChar attribute="Punctuation" context="#stay" char="{" beginRegion="Brace1" />
@@ -116,7 +124,8 @@
       <itemData name="Keyword"      defStyleNum="dsKeyword" spellChecking="false"/>
       <itemData name="Data Type"    defStyleNum="dsDataType" spellChecking="false"/>
       <itemData name="Int"          defStyleNum="dsDecVal" spellChecking="false"/>
-      <itemData name="Real"         defStyleNum="dsFloat" spellChecking="false"/>
+      <itemData name="Real"         defStyleNum="dsFloat"spellChecking="false"/>
+      <itemData name="Complex"         defStyleNum="dsFloat" spellChecking="false"/>
       <itemData name="String"       defStyleNum="dsString"/>
       <itemData name="Comment"      defStyleNum="dsComment"/>
       <itemData name="Assignment"   defStyleNum="dsNormal" spellChecking="false"/>


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #463. Use pandoc's [--syntax-definition](https://pandoc.org/MANUAL.html#option--syntax-definition) flag to pass the upstream stan.yml (from [skylighting](https://github.com/jgm/skylighting/blob/master/skylighting-core/xml/stan.xml)).

This highlighting will be built in to future versions of pandoc and we can remove the config in `_output.yml`

Previews:
![pdf highlighting](https://user-images.githubusercontent.com/31640292/148788907-2c5854bb-63e7-4ce5-bc08-147853dbf9a4.png)
![html highlighting](https://user-images.githubusercontent.com/31640292/148789007-cd369ad0-a42a-47bc-83f4-0c7eeb69d4b9.png)


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
