### PR TITLE
fix references to wrong bookdown version in build script and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub (re)builds and (re)deploys the website.
 
 The documentation source files are written in [Rmarkdown](https://rmarkdown.rstudio.com)
 and the RStudio's [bookdown package](https://github.com/rstudio/bookdown) converts these to HTML and pdf.
-**Required bookdown version:** 2.23 or higher, cf [the bookdown changelog](https://github.com/rstudio/bookdown/blob/main/NEWS.md#changes-in-bookdown-version-023).
+**Required bookdown version:** 0.23 or higher, cf [the bookdown changelog](https://github.com/rstudio/bookdown/blob/main/NEWS.md#changes-in-bookdown-version-023).
 Reported via [issue #380](https://github.com/stan-dev/docs/issues/380).
 
 

--- a/build.py
+++ b/build.py
@@ -34,11 +34,11 @@ def shexec(command):
         print('Command {} failed'.format(command))
         raise Exception(returncode)
 
-def check_bookdown_2_23():
+def check_bookdown_at_least_0_23():
     command = ["Rscript", "-e", "utils::packageVersion(\"bookdown\") > 0.22"]
     check = subprocess.run(command, capture_output=True, text=True)
     if not 'TRUE' in check.stdout:
-        print("R Package bookdown must be version 2.23, see README for build tools requirements")
+        print("R Package bookdown version must be at least 0.23, see README for build tools requirements")
         sys.exit(1)
 
 def safe_rm(fname):
@@ -77,7 +77,7 @@ def main():
     if sys.version_info < (3, 7):
         print('requires Python 3.7 or higher, found {}'.format(sys.version))
         sys.exit(1)
-    check_bookdown_2_23()
+    check_bookdown_at_least_0_23()
     global all_docs
     global all_formats
     if (len(sys.argv) > 2):


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary
In `build.py` script and `README.md` there was bookdown version 2.23 mentioned many times, even though 0.23 was probably meant. There are no functional changes in this PR, the version check is still  `> 0.22`, this just fixes text and name
of the version check function.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Juho Timonen
