### PR TITLE
Add log-logistic distribution to functions reference

### DIFF
--- a/src/functions-reference/positive_continuous_distributions.Rmd
+++ b/src/functions-reference/positive_continuous_distributions.Rmd
@@ -727,10 +727,12 @@ If $\alpha, \beta \in \mathbb{R}^+$, then for $y \in
 
 ### Sampling statement
 
-`y ~ ` **`loglogistic`**`(mu, sigma)`
+`y ~ ` **`loglogistic`**`(alpha, beta)`
 
-Increment target log probability density with `loglogistic_lupdf(y | mu, sigma)`.
+Increment target log probability density with unnormalized
+version of `loglogistic_lpdf(y | alpha, beta)`
 `r since("2.29")`
+
 <!-- real; loglogistic ~; -->
 \index{{\tt \bfseries loglogistic }!sampling statement|hyperpage}
 

--- a/src/functions-reference/positive_continuous_distributions.Rmd
+++ b/src/functions-reference/positive_continuous_distributions.Rmd
@@ -722,8 +722,8 @@ types, see section [vectorized PRNG functions](#prng-vectorization).
 
 If $\alpha, \beta \in \mathbb{R}^+$, then for $y \in
 \mathbb{R}^+$, \[ \text{Log-Logistic}(y|\alpha,\beta) = \frac{\
-\left(\frac{\beta}{\alpha}\right) \left(\frac{x}{\alpha}\right)^{\beta-1}\
-}{\left(1 + \left(\frac{x}{\alpha}\right)^\beta\right)^2} . \]
+\left(\frac{\beta}{\alpha}\right) \left(\frac{y}{\alpha}\right)^{\beta-1}\
+}{\left(1 + \left(\frac{y}{\alpha}\right)^\beta\right)^2} . \]
 
 ### Sampling statement
 

--- a/src/functions-reference/positive_continuous_distributions.Rmd
+++ b/src/functions-reference/positive_continuous_distributions.Rmd
@@ -714,3 +714,48 @@ Generate a Rayleigh variate with scale sigma; may only be used in
 generated quantities block. For a description of argument and return
 types, see section [vectorized PRNG functions](#prng-vectorization).
 `r since("2.18")`
+
+
+## Log-logistic distribution
+
+### Probability density function
+
+If $\alpha, \beta \in \mathbb{R}^+$, then for $y \in
+\mathbb{R}^+$, \[ \text{Log-Logistic}(y|\alpha,\beta) = \frac{\
+\left(\frac{\beta}{\alpha}\right) \left(\frac{x}{\alpha}\right)^{\beta-1}\
+}{\left(1 + \left(\frac{x}{\alpha}\right)^\beta\right)^2} . \]
+
+### Sampling statement
+
+`y ~ ` **`loglogistic`**`(mu, sigma)`
+
+Increment target log probability density with `loglogistic_lupdf(y | mu, sigma)`.
+`r since("2.29")`
+<!-- real; loglogistic ~; -->
+\index{{\tt \bfseries loglogistic }!sampling statement|hyperpage}
+
+### Stan functions
+
+<!-- real; loglogistic_lpdf; (reals y | reals alpha, reals beta); -->
+\index{{\tt \bfseries loglogistic\_lpdf }!{\tt (reals y \textbar\ reals alpha, reals beta): real}|hyperpage}
+
+`real` **`loglogistic_lpdf`**`(reals y | reals alpha, reals beta)`<br>\newline
+The log of the log-logistic density of y given shape parameters alpha and beta
+`r since("2.29")`
+
+<!-- real; loglogistic_cdf; (reals y, reals alpha, reals beta); -->
+\index{{\tt \bfseries loglogistic\_cdf }!{\tt (reals y, reals alpha, reals beta): real}|hyperpage}
+
+`real` **`loglogistic_cdf`**`(reals y, reals alpha, reals beta)`<br>\newline
+The log-logistic cumulative distribution function of y given shape parameters alpha and beta
+`r since("2.29")`
+
+<!-- R; loglogistic_rng; (reals mu, reals sigma); -->
+\index{{\tt \bfseries loglogistic\_rng}!{\tt (reals alpha, reals beta): R}|hyperpage}
+
+`R` **`loglogistic_rng`**`(reals alpha, reals beta)`<br>\newline
+Generate a log-logistic variate with shape parameters alpha and beta; may only
+be used in transformed data and generated quantities blocks.
+For a description of argument and return types, see section
+[vectorized PRNG functions](#prng-vectorization).
+`r since("2.29")`

--- a/src/functions-reference/positive_continuous_distributions.Rmd
+++ b/src/functions-reference/positive_continuous_distributions.Rmd
@@ -742,21 +742,21 @@ version of `loglogistic_lpdf(y | alpha, beta)`
 \index{{\tt \bfseries loglogistic\_lpdf }!{\tt (reals y \textbar\ reals alpha, reals beta): real}|hyperpage}
 
 `real` **`loglogistic_lpdf`**`(reals y | reals alpha, reals beta)`<br>\newline
-The log of the log-logistic density of y given shape parameters alpha and beta
+The log of the log-logistic density of y given scale alpha and shape beta
 `r since("2.29")`
 
 <!-- real; loglogistic_cdf; (reals y, reals alpha, reals beta); -->
 \index{{\tt \bfseries loglogistic\_cdf }!{\tt (reals y, reals alpha, reals beta): real}|hyperpage}
 
 `real` **`loglogistic_cdf`**`(reals y, reals alpha, reals beta)`<br>\newline
-The log-logistic cumulative distribution function of y given shape parameters alpha and beta
+The log-logistic cumulative distribution function of y given scale alpha and shape beta
 `r since("2.29")`
 
 <!-- R; loglogistic_rng; (reals mu, reals sigma); -->
 \index{{\tt \bfseries loglogistic\_rng}!{\tt (reals alpha, reals beta): R}|hyperpage}
 
 `R` **`loglogistic_rng`**`(reals alpha, reals beta)`<br>\newline
-Generate a log-logistic variate with shape parameters alpha and beta; may only
+Generate a log-logistic variate with scale alpha and shape beta; may only
 be used in transformed data and generated quantities blocks.
 For a description of argument and return types, see section
 [vectorized PRNG functions](#prng-vectorization).

--- a/src/functions-reference/unbounded_continuous_distributions.Rmd
+++ b/src/functions-reference/unbounded_continuous_distributions.Rmd
@@ -803,7 +803,6 @@ For a description of argument and return types, see section
 [vectorized PRNG functions](#prng-vectorization).
 `r since("2.18")`
 
-
 ## Gumbel distribution
 
 ### Probability density function

--- a/src/functions-reference/unbounded_continuous_distributions.Rmd
+++ b/src/functions-reference/unbounded_continuous_distributions.Rmd
@@ -803,6 +803,53 @@ For a description of argument and return types, see section
 [vectorized PRNG functions](#prng-vectorization).
 `r since("2.18")`
 
+
+## Log-logistic distribution
+
+### Probability density function
+
+If $\mu \in \mathbb{R}$ and $\sigma \in \mathbb{R}^+$, then for $y \in
+\mathbb{R}$, \[ \text{Logistic}(y|\mu,\sigma) = \frac{1}{\sigma} \
+\exp\!\left( - \, \frac{y - \mu}{\sigma} \right) \ \left(1 + \exp
+\!\left( - \, \frac{y - \mu}{\sigma} \right) \right)^{\!-2} \! . \]
+
+### Sampling statement
+
+`y ~ ` **`loglogistic`**`(mu, sigma)`
+
+Increment target log probability density with `loglogistic_lupdf(y | mu, sigma)`.
+`r since("2.29")`
+<!-- real; loglogistic ~; -->
+\index{{\tt \bfseries loglogistic }!sampling statement|hyperpage}
+
+### Stan functions
+
+<!-- real; loglogistic_lpdf; (reals y | reals mu, reals sigma); -->
+\index{{\tt \bfseries loglogistic\_lpdf }!{\tt (reals y \textbar\ reals mu, reals sigma): real}|hyperpage}
+
+`real` **`loglogistic_lpdf`**`(reals y | reals mu, reals sigma)`<br>\newline
+The log of the log-logistic density of y given location mu and scale sigma
+`r since("2.29")`
+
+<!-- real; loglogistic_cdf; (reals y, reals mu, reals sigma); -->
+\index{{\tt \bfseries loglogistic\_cdf }!{\tt (reals y, reals mu, reals sigma): real}|hyperpage}
+
+`real` **`loglogistic_cdf`**`(reals y, reals mu, reals sigma)`<br>\newline
+The log-logistic cumulative distribution function of y given location mu
+and scale sigma
+`r since("2.29")`
+
+<!-- R; loglogistic_rng; (reals mu, reals sigma); -->
+\index{{\tt \bfseries loglogistic\_rng}!{\tt (reals mu, reals sigma): R}|hyperpage}
+
+`R` **`loglogistic_rng`**`(reals mu, reals sigma)`<br>\newline
+Generate a log-logistic variate with location mu and scale sigma; may only
+be used in transformed data and generated quantities blocks.
+For a description of argument and return types, see section
+[vectorized PRNG functions](#prng-vectorization).
+`r since("2.29")`
+
+
 ## Gumbel distribution
 
 ### Probability density function

--- a/src/functions-reference/unbounded_continuous_distributions.Rmd
+++ b/src/functions-reference/unbounded_continuous_distributions.Rmd
@@ -804,52 +804,6 @@ For a description of argument and return types, see section
 `r since("2.18")`
 
 
-## Log-logistic distribution
-
-### Probability density function
-
-If $\mu \in \mathbb{R}$ and $\sigma \in \mathbb{R}^+$, then for $y \in
-\mathbb{R}$, \[ \text{Logistic}(y|\mu,\sigma) = \frac{1}{\sigma} \
-\exp\!\left( - \, \frac{y - \mu}{\sigma} \right) \ \left(1 + \exp
-\!\left( - \, \frac{y - \mu}{\sigma} \right) \right)^{\!-2} \! . \]
-
-### Sampling statement
-
-`y ~ ` **`loglogistic`**`(mu, sigma)`
-
-Increment target log probability density with `loglogistic_lupdf(y | mu, sigma)`.
-`r since("2.29")`
-<!-- real; loglogistic ~; -->
-\index{{\tt \bfseries loglogistic }!sampling statement|hyperpage}
-
-### Stan functions
-
-<!-- real; loglogistic_lpdf; (reals y | reals mu, reals sigma); -->
-\index{{\tt \bfseries loglogistic\_lpdf }!{\tt (reals y \textbar\ reals mu, reals sigma): real}|hyperpage}
-
-`real` **`loglogistic_lpdf`**`(reals y | reals mu, reals sigma)`<br>\newline
-The log of the log-logistic density of y given location mu and scale sigma
-`r since("2.29")`
-
-<!-- real; loglogistic_cdf; (reals y, reals mu, reals sigma); -->
-\index{{\tt \bfseries loglogistic\_cdf }!{\tt (reals y, reals mu, reals sigma): real}|hyperpage}
-
-`real` **`loglogistic_cdf`**`(reals y, reals mu, reals sigma)`<br>\newline
-The log-logistic cumulative distribution function of y given location mu
-and scale sigma
-`r since("2.29")`
-
-<!-- R; loglogistic_rng; (reals mu, reals sigma); -->
-\index{{\tt \bfseries loglogistic\_rng}!{\tt (reals mu, reals sigma): R}|hyperpage}
-
-`R` **`loglogistic_rng`**`(reals mu, reals sigma)`<br>\newline
-Generate a log-logistic variate with location mu and scale sigma; may only
-be used in transformed data and generated quantities blocks.
-For a description of argument and return types, see section
-[vectorized PRNG functions](#prng-vectorization).
-`r since("2.29")`
-
-
 ## Gumbel distribution
 
 ### Probability density function


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds the Stan functions related to log-logistic distribution to functions reference. Needed for [1094](https://github.com/stan-dev/stanc3/pull/1094) in stanc3. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Juho Timonen