### PR TITLE
Delete CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-## Stan Documentation Issues
-
-If you would like to make a suggestion for fixing a typo or unclear part of the docs, please make a comment on the currently open next docs issue (it will be numbered by current release followed by `++`) and we will fix it in the next release after the current release:
-
-* [Next release Stan documentation](https://github.com/stan-dev/docs/issues?utf8=✓&q=is%3Aopen%20label%3Abug)
-
-This is easier for us than having to deal with a typo pull request, though we will gladly take those, too.


### PR DESCRIPTION
#### Summary

We currently have a `.github/CONTRIBUTING.md` which contains exclusively outdated information:

> If you would like to make a suggestion for fixing a typo or unclear part of the docs, please make a comment on the currently open next docs issue (it will be numbered by current release followed by `++`) and we will fix it in the next release after the current release

We have not had such a standing issue for a while, my guess is that this was written when the docs were stored with the code?

At any rate, it is confusing (see #506, #429) and we've been accepting typo issues/PRs, so I think we're better off deleting this so it isn't shown to new contributors. 


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
