### PR TITLE
Add edit button in html, use the same syntax highlighting in both formats

### DIFF
--- a/src/cmdstan-guide/_output.yml
+++ b/src/cmdstan-guide/_output.yml
@@ -2,13 +2,16 @@ bookdown::gitbook:
   code folding: hide
   css: stan-manual.css
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   split_by: "chapter"
   config:
     search:
         engine: lunr
     sharing: null
     download: null
-    edit: null
+    edit:
+      link: https://github.com/stan-dev/docs/tree/master/src/cmdstan-guide/%s
+      text: "Edit"
     toolbar:
       position: static
     fontsettings:
@@ -26,5 +29,6 @@ subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   includes:
     in_header: header.tex

--- a/src/functions-reference/_output.yml
+++ b/src/functions-reference/_output.yml
@@ -2,12 +2,15 @@ bookdown::gitbook:
   css: ../stan-manual.css
   split_by: "section"
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   config:
     search:
         engine: lunr
     sharing: null
     download: null
-    edit: null
+    edit:
+      link: https://github.com/stan-dev/docs/tree/master/src/functions-reference/%s
+      text: "Edit"
     toolbar:
       position: static
     fontsettings:
@@ -24,6 +27,7 @@ subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   includes:
     in_header: header.tex
     after_body: postamble.tex

--- a/src/reference-manual/_output.yml
+++ b/src/reference-manual/_output.yml
@@ -2,12 +2,15 @@ bookdown::gitbook:
   css: ../stan-manual.css
   split_by: "section"
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   config:
     search:
         engine: lunr
     sharing: null
     download: null
-    edit: null
+    edit:
+      link: https://github.com/stan-dev/docs/tree/master/src/reference-manual/%s
+      text: "Edit"
     toolbar:
       position: static
     fontsettings:
@@ -25,5 +28,6 @@ subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   includes:
     in_header: header.tex

--- a/src/stan-users-guide/_output.yml
+++ b/src/stan-users-guide/_output.yml
@@ -3,12 +3,15 @@ bookdown::gitbook:
   css: stan-manual.css
   split_by: "section"
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   config:
     search:
         engine: lunr
     sharing: null
     download: null
-    edit: null
+    edit:
+      link: https://github.com/stan-dev/docs/tree/master/src/stan-users-guide/%s
+      text: "Edit"
     toolbar:
       position: static
     fontsettings:
@@ -26,5 +29,6 @@ subparagraph: yes
 bookdown::pdf_book:
   latex_engine: "pdflatex"
   pandoc_args: ["--syntax-definition","../stan.xml"]
+  highlight: tango
   includes:
     in_header: header.tex


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] Declare copyright holder and open-source license: see below

#### Summary

After a request on the [forums](https://discourse.mc-stan.org/t/feature-request-for-documentation/27158), this adds a link in the corner of the docs. Clicking on it takes you to the source file on github of the specific page. 
![Edit button](https://user-images.githubusercontent.com/31640292/163581534-c87e3ffa-3421-41da-941f-4dc20dfa8da9.png)

This also sets the same highlight theme for both HTML and PDF outputs. Previously pdf used 'tango' and the html used 'pygments'. This sets both to 'tango', which @bob-carpenter and I think looks best of the options. Here are the options:


![haddock](https://user-images.githubusercontent.com/31640292/163581688-9ed666d4-901e-4495-9ef0-7614d4c26721.png)
![kate](https://user-images.githubusercontent.com/31640292/163581691-aebdc0b0-5e15-4f85-8beb-c2b3b27f7ae7.png)
![monochrome](https://user-images.githubusercontent.com/31640292/163581693-327a1510-105e-4a14-8d66-594415fd5b8a.png)
![pygments](https://user-images.githubusercontent.com/31640292/163581694-ad4be132-059a-44f3-a5a4-b0c7a7d7ec74.png)
![tango](https://user-images.githubusercontent.com/31640292/163581696-d6408bf8-6faf-4a02-b296-82a45ba18fb6.png)


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
