### PR TITLE
Add section on block-specific semantic requirements

### DIFF
--- a/src/reference-manual/syntax.Rmd
+++ b/src/reference-manual/syntax.Rmd
@@ -429,12 +429,34 @@ The `break` and `continue` statements may only be used
 within the body of a for-loop or while-loop.
 
 
-### PRNG function locations {-}
+### Block-specific restrictions
 
-Functions ending in `_rng` may only be called in the transformed
-data and generated quantities block, and within the bodies of
+Some constructs in the Stan language are only allowed in certain blocks or in
+certain kinds of user-defiend functions.
+
+#### PRNG functions
+
+Functions ending in `_rng` may only be called in the `transformed
+data` and `generated quantities` block, and within the bodies of
 user-defined functions with names ending in `_rng`.
 
+#### Unnormalized distributions
+
+Unnormalized distributions (with suffixes `_lupmf` or `_lupdf`) may only be
+called in the `model` block, user-defined probability functions, or within the
+bodies of user defined functions which end in `_lp`.
+
+#### Incrementing and accessing target
+
+`target +=` statements can only be used inside of the `model` block or
+user-defined functions which end in `_lp`.
+
+User defined functions which end in `_lp` and the `target()` function can only
+be used in the `model` block, `transformed parameters` block, and in the bodies
+of other user defined functions which end in `_lp`.
+
+Sampling statements (using `~`) can only be used in the `model` block or in the
+bodies of user-defined functions which end in `_lp`.
 
 ### Probability function naming {-}
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

This extends the "Extra-grammatical constraints" section of the language reference to include:

1. Rules about `_rng` functions (previously listed, moved to this new subheading)
2. Rules about `_lupdf` and `_lupmf`
3. Rules about `target +=`, `target()`, and user defined `_lp` functions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
