### PR TITLE
Document abs/fabs changes

### DIFF
--- a/src/functions-reference/complex-valued_basic_functions.Rmd
+++ b/src/functions-reference/complex-valued_basic_functions.Rmd
@@ -291,7 +291,12 @@ magnitude, which for $z = x + yi$ is
 \[
 \textrm{abs}(z) = \sqrt{x^2 + y^2}.
 \]
-`r since("2.28")`
+
+This function works elementwise over containers, returning the same shape and
+kind of the input container but holding reals. For example, a
+`complex_vector[n]` input will return a `vector[n]` output, with each element
+transformed by the above equation.
+`r since("2.28, vectorized in 2.30")`
 
 <!-- real; arg; (complex z); -->
 \index{{\tt \bfseries arg }!{\tt (complex z): real}|hyperpage}

--- a/src/functions-reference/deprecated_functions.Rmd
+++ b/src/functions-reference/deprecated_functions.Rmd
@@ -31,10 +31,16 @@ these on the behalf of the user.
 
 *Scheduled Removal*: Stan 2.32
 
-## `abs(real x)` function
 
-*Deprecated*: Use of the `abs` function with real-valued arguments
-              is deprecated; use functions `fabs` instead.
+## `fabs` function
+
+*Deprecated*: The unary function `fabs` is deprecated.
+
+*Replacement*: Use the unary function `abs` instead. Note that the return type
+for `abs` is different for integer overloads, but this replacement is safe due
+to Stan's type promotion rules.
+
+*Scheduled Removal*: Stan 2.33
 
 
 ## Integer division with `operator/`

--- a/src/functions-reference/integer-valued_basic_functions.Rmd
+++ b/src/functions-reference/integer-valued_basic_functions.Rmd
@@ -135,12 +135,13 @@ This is a no-op. \[ \text{operator+}(x) = x \]
 
 ## Absolute functions
 
-<!-- R; abs; (T x); -->
-\index{{\tt \bfseries abs }!{\tt (T x): R}|hyperpage}
+<!-- T; abs; (T x); -->
+\index{{\tt \bfseries abs }!{\tt (T x): T}|hyperpage}
 
-`R` **`abs`**`(T x)`<br>\newline
-absolute value of x
-`r since("2.0")`
+`T` **`abs`**`(T x)`<br>\newline
+The absolute value of x. This function works elementwise over containers such as
+arrays.
+`r since("2.0, vectorized in 2.30")`
 
 <!-- int; int_step; (int x); -->
 \index{{\tt \bfseries int\_step }!{\tt (int x): int}|hyperpage}
@@ -192,4 +193,3 @@ Return the maximum of x and y. \[ \text{max}(x, y) = \begin{cases} x &
 
 Return the size of `x` which for scalar-valued `x` is 1
 `r since("2.26")`
-

--- a/src/functions-reference/integer-valued_basic_functions.Rmd
+++ b/src/functions-reference/integer-valued_basic_functions.Rmd
@@ -139,8 +139,11 @@ This is a no-op. \[ \text{operator+}(x) = x \]
 \index{{\tt \bfseries abs }!{\tt (T x): T}|hyperpage}
 
 `T` **`abs`**`(T x)`<br>\newline
-The absolute value of x. This function works elementwise over containers such as
-arrays.
+The absolute value of x.
+
+This function works elementwise over containers such as vectors.
+Given a type `T` which is `int`, or an array of `int`s, `abs` returns the same
+type where each element has had its absolute value taken.
 `r since("2.0, vectorized in 2.30")`
 
 <!-- int; int_step; (int x); -->

--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -687,12 +687,20 @@ used in the   data, transformed data, or generated quantities blocks.*
 
 ### Absolute value functions
 
+<!-- T; abs; (T x); -->
+\index{{\tt \bfseries abs }!{\tt (T x): T}|hyperpage}
+
+`T` **`abs`**`(T x)`<br>\newline
+The absolute value of x. This function works elementwise over containers such as
+vectors.
+`r since("2.0, vectorized in 2.30")`
+
 <!-- R; fabs; (T x); -->
 \index{{\tt \bfseries fabs }!{\tt (T x): R}|hyperpage}
 
 `R` **`fabs`**`(T x)`<br>\newline
 absolute value of x
-`r since("2.0, vectorized in 2.13")`
+`r since("2.0, vectorized in 2.13, deprecated in 2.30")`
 
 <!-- real; fdim; (real x, real y); -->
 \index{{\tt \bfseries fdim }!{\tt (real x, real y): real}|hyperpage}

--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -691,8 +691,12 @@ used in the   data, transformed data, or generated quantities blocks.*
 \index{{\tt \bfseries abs }!{\tt (T x): T}|hyperpage}
 
 `T` **`abs`**`(T x)`<br>\newline
-The absolute value of x. This function works elementwise over containers such as
-vectors.
+The absolute value of x.
+
+This function works elementwise over containers such as vectors.
+Given a type `T` which is `real` `vector`, `row_vector`, `matrix`, or an array
+of those types, `abs` returns the same type where each element has had its
+absolute value taken.
 `r since("2.0, vectorized in 2.30")`
 
 <!-- R; fabs; (T x); -->


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Documentation for https://github.com/stan-dev/stanc3/pull/1195. Closes #523.

`abs` is now vectorized. The previous note about it being deprecated for real arguments is removed, `fabs` is now deprecated instead.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
