### PR TITLE
Expand documentation around `xc` in integration

### DIFF
--- a/src/stan-users-guide/one-dimensional-integrals.Rmd
+++ b/src/stan-users-guide/one-dimensional-integrals.Rmd
@@ -169,10 +169,10 @@ The issue is that there will be numerical breakdown in the precision of
 precision of double precision floating numbers. This integral will fail to
 converge for values of `alpha` and `beta` much less than one.
 
-This is where `xc` is useful. It is defined, for definite integrals,
-as a high precision version of the distance from `x` to the nearest
-endpoint. To make use of this for the beta integral, the integrand can be
-re-coded:
+This is where `xc` is useful. It is defined, for definite integrals, as a high
+precision version of the distance from `x` to the nearest endpoint --- `a - x`
+or `b - x` for a lower endpoint `a` and an upper endpoint `b`. To make use of
+this for the beta integral, the integrand can be re-coded:
 
 ```stan
 real beta(real x, real xc, array[] real theta, array[] real x_r, array[] int x_i) {
@@ -190,8 +190,100 @@ real beta(real x, real xc, array[] real theta, array[] real x_r, array[] int x_i
 }
 ```
 
-This version of the integrand will converge for much smaller values of
-`alpha` and `beta` than otherwise possible.
+In this case, as we approach the upper limit of integration $a = 1$, `xc` will
+take on the value of $a - x = 1 - x$. This version of the integrand will
+converge for much smaller values of `alpha` and `beta` than otherwise possible.
+
+Consider another example: let's say we have a log-normal distribution that is
+both shifted away from zero by some amount $\delta$, and truncated at some
+value $b$. If we were interested in calculating the expectation of a variable
+$X$ distributed in this way, we would need to calculate
+$$
+\int_a^b xf(x)\,dx = \int_{\delta}^b xf(x)\,dx
+$$
+in the numerator, where $f(x)$ is the probability density function for the
+shifted log-normal distribution. This probability density function can be
+coded in Stan as:
+
+```stan
+real shift_lognormal_pdf(real x,
+                         real mu,
+                         real sigma,
+                         real delta) {
+  real p;
+
+  p = (1.0 / ((x - delta) * sigma * sqrt(2 * pi()))) *
+    exp(-1 * (log(x - delta) - mu)^2 / (2 * sigma^2));
+
+  return p;
+}
+```
+
+Therefore, the function that we want to integrate is:
+
+```stan
+real integrand(real x,
+               real xc,
+               array[] real theta,
+               array[] real x_r,
+               array[] int x_i) {
+  real numerator;
+  real p;
+
+  real mu = theta[1];
+  real sigma = theta[2];
+  real delta = theta[3];
+  real b = theta[4];
+
+  p = shift_lognormal_pdf(x, mu, sigma, delta);
+
+  numerator = x * p;
+
+  return numerator;
+}
+```
+
+What happens here is that, given that the log-normal distribution is shifted by
+$\delta$, when we then try to integrate the numerator, our `x` starts at
+values just above `delta`. This, in turn, causes the `x - delta` term to be
+near zero, leading to a breakdown.
+
+We can use `xc`, and define the `integrand` as:
+
+```stan
+real integrand(real x,
+               real xc,
+               array[] real theta,
+               array[] real x_r,
+               array[] int x_i) {
+  real numerator;
+  real p;
+
+  real mu = theta[1];
+  real sigma = theta[2];
+  real delta = theta[3];
+  real b = theta[4];
+
+  if (x < delta + 1) {
+    p = shift_lognormal_pdf(xc, mu, sigma, delta);
+  } else {
+    p = shift_lognormal_pdf(x, mu, sigma, delta);
+  }
+
+  numerator = x * p;
+
+  return numerator;
+}
+```
+
+Why does this work? When our values of `x` are less than `delta + 1` (so, when
+they're near `delta`, given that our lower bound of integration is equal to
+$\delta$), we pass `xc` as an argument to our `shift_lognormal_pdf` function.
+This way, instead of dealing with `x - delta` in `shift_lognormal_pdf`, we are
+working with `xc - delta` which is equal to `delta - x - delta`, as `delta` is
+the lower endpoint in that case. The `delta` terms cancel out, and we are left
+with a high-precision version of `x`. We don't encounter the same problem at
+the upper limit $b$ so we don't adjust the code for that case.
 
 Note, `xc` is only used for definite integrals. If either the left endpoint
 is at negative infinity or the right endpoint is at positive infinity, `xc`
@@ -201,5 +293,5 @@ For zero-crossing definite integrals (see section [Zero Crossing](#zero-crossing
 integrals are broken into two pieces ($(a, 0)$ and $(0, b)$ for endpoints
 $a < 0$ and $b > 0$) and `xc` is a high precision version of the distance
 to the limits of each of the two integrals separately. This means `xc` will
-be the a high precision version of `a - x`, `x`, or `b - x`,
+be a high precision version of `a - x`, `x`, or `b - x`,
 depending on the value of x and the endpoints.


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally **NOTE** I *do* get this warning with `bookdown::render_book('index.Rmd')`
```
`Warning message:
In file.rename(files[i], files2[i]) :
  cannot rename file 'optimization.html' to '_book/optimization.html', reason 'No such file or directory'`
```
- [X] New functions marked with `` `r since("VERSION")` ``
- [X] Declare copyright holder and open-source license: see below

#### Summary

Added another example to the one-dimensional integration chapter. Tried to use it to clarify the usage of `xc`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): I am the copyright holder.



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
