### PR TITLE
correct von_mises probability function return types

### DIFF
--- a/src/functions-reference/circular_distributions.Rmd
+++ b/src/functions-reference/circular_distributions.Rmd
@@ -46,42 +46,42 @@ Increment target log probability density with `von_mises_lupdf(y | mu, kappa)`.
 
 ### Stan functions
 
-<!-- R; von_mises_lpdf; (reals y | reals mu, reals kappa); -->
-\index{{\tt \bfseries von\_mises\_lpdf }!{\tt (reals y \textbar\ reals mu, reals kappa): R}|hyperpage}
+<!-- real; von_mises_lpdf; (reals y | reals mu, reals kappa); -->
+\index{{\tt \bfseries von\_mises\_lpdf }!{\tt (reals y \textbar\ reals mu, reals kappa): real}|hyperpage}
 
-`R` **`von_mises_lpdf`**`(reals y | reals mu, reals kappa)`<br>\newline
+`real` **`von_mises_lpdf`**`(reals y | reals mu, reals kappa)`<br>\newline
 The log of the von mises density of y given location mu and scale
 kappa.
 `r since("2.18")`
 
-<!-- R; von_mises_lupdf; (reals y | reals mu, reals kappa); -->
-\index{{\tt \bfseries von\_mises\_lupdf }!{\tt (reals y \textbar\ reals mu, reals kappa): R}|hyperpage}
+<!-- real; von_mises_lupdf; (reals y | reals mu, reals kappa); -->
+\index{{\tt \bfseries von\_mises\_lupdf }!{\tt (reals y \textbar\ reals mu, reals kappa): real}|hyperpage}
 
-`R` **`von_mises_lupdf`**`(reals y | reals mu, reals kappa)`<br>\newline
+`real` **`von_mises_lupdf`**`(reals y | reals mu, reals kappa)`<br>\newline
 The log of the von mises density of y given location mu and scale
 kappa dropping constant additive terms.
 `r since("2.25")`
 
-<!-- R; von_mises_cdf; (reals y | reals mu, reals kappa); -->
-\index{{\tt \bfseries von\_mises\_cdf }!{\tt (reals y \textbar\ reals mu, reals kappa): R}|hyperpage}
+<!-- real; von_mises_cdf; (reals y | reals mu, reals kappa); -->
+\index{{\tt \bfseries von\_mises\_cdf }!{\tt (reals y \textbar\ reals mu, reals kappa): real}|hyperpage}
 
-`R` **`von_mises_cdf`**`(reals y | reals mu, reals kappa)`<br>\newline
+`real` **`von_mises_cdf`**`(reals y | reals mu, reals kappa)`<br>\newline
 The von mises cumulative distribution function of y given location mu and scale
 kappa.
 `r since("2.29")`
 
-<!-- R; von_mises_lcdf; (reals y | reals mu, reals kappa); -->
-\index{{\tt \bfseries von\_mises\_lcdf }!{\tt (reals y \textbar\ reals mu, reals kappa): R}|hyperpage}
+<!-- real; von_mises_lcdf; (reals y | reals mu, reals kappa); -->
+\index{{\tt \bfseries von\_mises\_lcdf }!{\tt (reals y \textbar\ reals mu, reals kappa): real}|hyperpage}
 
-`R` **`von_mises_lcdf`**`(reals y | reals mu, reals kappa)`<br>\newline
+`real` **`von_mises_lcdf`**`(reals y | reals mu, reals kappa)`<br>\newline
 The log of the von mises cumulative distribution function of y given location mu and scale
 kappa.
 `r since("2.29")`
 
-<!-- R; von_mises_lccdf; (reals y | reals mu, reals kappa); -->
-\index{{\tt \bfseries von\_mises\_lcdf }!{\tt (reals y \textbar\ reals mu, reals kappa): R}|hyperpage}
+<!-- real; von_mises_lccdf; (reals y | reals mu, reals kappa); -->
+\index{{\tt \bfseries von\_mises\_lcdf }!{\tt (reals y \textbar\ reals mu, reals kappa): real}|hyperpage}
 
-`R` **`von_mises_lccdf`**`(reals y | reals mu, reals kappa)`<br>\newline
+`real` **`von_mises_lccdf`**`(reals y | reals mu, reals kappa)`<br>\newline
 The log of the von mises complementary cumulative distribution function of y given location mu and scale
 kappa.
 `r since("2.29")`


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` `` 
- [x] Declare copyright holder and open-source license: see below

#### Summary
The documentation of the return type for all `von_mises_` related Stan probability functions has been changed from `R` to the correct return type `real`. This fixes https://github.com/stan-dev/docs/issues/574

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
