### PR TITLE
Corrected reference to a vector as "y" to "z" in sparse ragged docs

### DIFF
--- a/src/stan-users-guide/sparse-ragged.Rmd
+++ b/src/stan-users-guide/sparse-ragged.Rmd
@@ -172,7 +172,7 @@ cat(ifelse(knitr::is_html_output(), "</td></tr></table>",
 
 On the left is the definition of a ragged data structure $y$ with three rows of
 different sizes ($y_1$ is size 3, $y_2$ size 2, and $y_3$ size 4).  On the right
-is an example of how to code the data in Stan, using a single vector $y$ to hold
+is an example of how to code the data in Stan, using a single vector $z$ to hold
 all the values and a separate array of integers $s$ to hold the group row sizes.
 In this example, $y_1 = z_{1:3}$, $y_2 = z_{4:5}$, and $y_3 = z_{6:9}$.
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Builds locally 
- [ ] New functions marked with `` `r since("VERSION")` ``
- [ ] Declare copyright holder and open-source license: see below

#### Summary

Changed a single letter in the documentation!

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
