### PR TITLE
wrong brackets for a vector

### DIFF
--- a/src/stan-users-guide/algebraic-equations.Rmd
+++ b/src/stan-users-guide/algebraic-equations.Rmd
@@ -95,13 +95,13 @@ The following code returns the solution to our nonlinear algebraic system:
 
 ```stan
 transformed data {
-  vector[2] y_guess = {1, 1};
+  vector[2] y_guess = [1, 1]';
   array[0] real x_r;
   array[0] int x_i;
 }
 
 transformed parameters {
-  vector[2] theta = {3, 6};
+  vector[2] theta = [3, 6]';
   vector[2] y;
 
   y = algebra_solver_newton(system, y_guess, theta, x_r, x_i);


### PR DESCRIPTION
#### Summary
Just a tiny issue, the brackets for vectors were wrong. {.} rather than [.]'
 
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Bruno Nicenboim


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
