### PR TITLE
Update documentation on truncation to note vectorized capability

### DIFF
--- a/src/reference-manual/statements.Rmd
+++ b/src/reference-manual/statements.Rmd
@@ -793,8 +793,14 @@ probability, which in turn results in the sample being rejected.
 
 #### Vectorizing truncated distributions {-}
 
-Stan does not (yet) support vectorization of distribution functions
-with truncation.
+Vectorization of distribution functions with truncation
+is available if the underlying distribution, `lcdf`, and `lccdf` functions
+meet the required signatures.
+
+Note that at the moment, lower-and-upper truncated distrubution may generate a
+for-loop internally as part of translating the truncation statement. This is
+still preferable to manually constructing a loop, since the distribution
+function itself can still be evaluated in a vectorized manner.
 
 
 ## For loops

--- a/src/reference-manual/statements.Rmd
+++ b/src/reference-manual/statements.Rmd
@@ -797,10 +797,28 @@ Vectorization of distribution functions with truncation
 is available if the underlying distribution, `lcdf`, and `lccdf` functions
 meet the required signatures.
 
-Note that at the moment, lower-and-upper truncated distrubution may generate a
-for-loop internally as part of translating the truncation statement. This is
+The equivalent code for a vectorized truncation depends on which of the
+variables are non-scalars (arrays, vectors, etc.):
+
+1. If the variate `y` is the only non-scalar, the result is the same as
+   described in the above sections, but the `lcdf`/`lccdf` calculation is multiplied
+   by `size(y)`.
+
+2. If the other arguments to the distribution are non-scalars, then the
+   vectorized version of the `lcdf`/`lccdf` is used. These functions return the
+   sum of their terms, so no multiplication by the size is needed.
+
+3. The exception to the above is when a non-variate is a vector and both a lower
+   and upper bound are specified in the truncation. In this case, a for loop is
+   generated over the elements of the non-scalar arguments. This is required
+   since the `log_diff_exp` of two sums is not the same as the sum of the
+   pairwise `log_diff_exp` operations.
+
+Note that while a lower-and-upper truncated distrubution may generate a
+for-loop internally as part of translating the truncation statement, this is
 still preferable to manually constructing a loop, since the distribution
 function itself can still be evaluated in a vectorized manner.
+
 
 
 ## For loops

--- a/src/stan-users-guide/for-bugs-users.Rmd
+++ b/src/stan-users-guide/for-bugs-users.Rmd
@@ -235,7 +235,7 @@ programming language and examine at the example models.
 
 Stan allows all sorts of tricks with vector and matrix operations
 which can make Stan models more compact.  For example, arguments to
-probability functions may be vectorized,^[Most distributions have been vectorized, but currently the truncated versions may not exist and may not be vectorized.]
+probability functions may be vectorized,^[Most distributions have been vectorized, but currently the truncated versions may not exist.]
 allowing
 ```stan
 for (i in 1:n) {

--- a/src/stan-users-guide/truncation-censoring.Rmd
+++ b/src/stan-users-guide/truncation-censoring.Rmd
@@ -35,9 +35,7 @@ parameters {
   real<lower=0> sigma;
 }
 model {
-  for (n in 1:N) {
-    y[n] ~ normal(mu, sigma) T[ , U];
-  }
+  y ~ normal(mu, sigma) T[ , U];
 }
 ```
 
@@ -57,12 +55,10 @@ will evaluate to $-\infty$.  For instance, if variate `y` is
 sampled with the statement.
 
 ```stan
-for (n in 1:N) {
-  y[n] ~ normal(mu, sigma) T[L, U];
-}
+y ~ normal(mu, sigma) T[L, U];
 ```
 
-then if the value of `y[n]` is less than the value of `L`
+then if any value inside `y` is less than the value of `L`
 or greater than the value of `U`, the sampling statement produces
 a zero-probability estimate.  For user-defined truncation, this
 zeroing outside of truncation bounds must be handled explicitly.
@@ -123,9 +119,7 @@ parameters {
 model {
   L ~ // ...
   U ~ // ...
-  for (n in 1:N) {
-    y[n] ~ normal(mu, sigma) T[L, U];
-  }
+  y ~ normal(mu, sigma) T[L, U];
 }
 ```
 
@@ -257,5 +251,3 @@ model {
   target += N_cens * normal_lcdf(L | mu, sigma);
 }
 ```
-
-


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Documentation for https://github.com/stan-dev/stanc3/pull/1263. I mostly just updated the examples and removed any statement saying this was _not_ possible. I'm not sure how into the specific translation of the `T [ , ]` syntax we should get, since it is both a bit case-dependent (depending on which of the arguments is vectorized) and may change in the future if we get improved Math functions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
