### PR TITLE
users guide: cross-validation.Rmd: fix typo on log-sum-exp definition

### DIFF
--- a/src/stan-users-guide/cross-validation.Rmd
+++ b/src/stan-users-guide/cross-validation.Rmd
@@ -70,7 +70,7 @@ underflow and maintain high arithmetic precision as
 $$
 \textrm{log-sum-exp}_{m = 1}^M \mu_m
 = \textrm{max}(\mu)
-+ \sum_{m = 1}^M \exp(\mu_m - \textrm{max}(\mu)).
++ \log \sum_{m = 1}^M \exp(\mu_m - \textrm{max}(\mu)).
 $$
 Pulling the maximum out preserves all of its precision.  By
 subtracting the maximum, the terms $\mu_m - \textrm{max}(\mu) \leq 0$,


### PR DESCRIPTION

#### Summary

Fix missing "log" from definition of log-sum-exp in cross-validation.Rmd in the documentation.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Adam Massmann

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
