### PR TITLE
Add word tilde to the subsection about the sampling statement

### DIFF
--- a/src/reference-manual/statements.Rmd
+++ b/src/reference-manual/statements.Rmd
@@ -374,12 +374,15 @@ The name "sampling statement" is meant to be suggestive, not
 interpreted literally.  Conceptually, the variable `y`, which may
 be an unknown parameter or known, modeled data, is being declared
 to have the distribution indicated by the right-hand side of the
-sampling statement.
+sampling statement. The above statement can read as "y is distributed
+as normal distribution with parameters mu and sigma.". The symbol `~` 
+is called tilde.
 
 Executing such a statement does not perform any sampling.  In Stan, a
-sampling statement is merely a notational convenience.  The above
+sampling statement is merely a notational convenience following the typical
+notation used to present models in the literature.  The above
 sampling statement could be expressed as a direct increment on the
-total log probability as
+total log probability density as
 
 ```stan
 target += normal_lpdf(y | mu, sigma);


### PR DESCRIPTION
To make it easier to find the relevant section about ~ for those who don't know the term "sampling statement", mention that the symbol is called tilde (the plain symbol ~ is unsearchable with web search engines). Added also a sentence about how to read such statement.

#### Submission Checklist

Minor doc change

#### Copyright and Licensing

I suspect that this small change would be worth of such intellectual contribution worthy of copyright, but here goes

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Aki Vehtari

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
