### PR TITLE
Remove outdated section on array promotion

### DIFF
--- a/src/reference-manual/expressions.Rmd
+++ b/src/reference-manual/expressions.Rmd
@@ -402,29 +402,6 @@ zero-element array.
 array[0] int a;   // a is fully defined as zero element array
 ```
 
-
-#### Integer only array expressions {-}
-
-If an array expression contains only integer elements, such as
-`{ 1, 2, 3 }`, then the result type will be an integer array,
-`array [] real`.  This means that the following will *not* be
-legal.
-
-```stan
-array[2] real a = { -3, 12 };
-// error: array [] real can't be assigned to array [] real
-```
-
-Integer arrays may not be assigned to real values.  However, this
-problem is easily sidestepped by using real literal expressions.
-
-```stan
-array[2] real a = { -3.0, 12.0 };
-```
-
-Now the types match and the assignment is allowed.
-
-
 ## Parentheses for grouping
 
 Any expression wrapped in parentheses is also an expression. Like in


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Removes the section on ["Integer only array expressions"](https://mc-stan.org/docs/reference-manual/vector-matrix-array-expressions.html#integer-only-array-expressions) which 1) had incorrect types in it's examples and 2) has not been true since arrays became covariant.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
