### PR TITLE
Adding escape character to an asterisk

### DIFF
--- a/src/stan-users-guide/parallelization.Rmd
+++ b/src/stan-users-guide/parallelization.Rmd
@@ -755,4 +755,4 @@ and GPUs with OpenCL:
 - uniform_lpdf
 - weibull_lpdf
 
-* OpenCL is not used when the covariate argument to the GLM functions is a `row_vector`.
+\* OpenCL is not used when the covariate argument to the GLM functions is a `row_vector`.


### PR DESCRIPTION
The asterisk used to indicate limitations with a GLM functions in OpenCL is being treated by markdown as a bulletpoint. 


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
