### PR TITLE
Update permutation_rng example

### DIFF
--- a/src/stan-users-guide/cross-validation.Rmd
+++ b/src/stan-users-guide/cross-validation.Rmd
@@ -285,27 +285,25 @@ Stan, the simplest approach is the following.
 ```stan
 functions {
   array[] int permutation_rng(int N) {
-     int N = rows(x);
-     array[N] int y;
-     for (n in 1:N) {
-       y[n] = n;
-     }
-     vector[N] theta = rep_vector(1.0 / N, N);
-     for (n in 1:rows(y)) {
-       int i = categorical_rng(theta);
-     }
-      array[n] int temp = y;
+    array[N] int y;
+    for (n in 1 : N) {
+      y[n] = n;
+    }
+    vector[N] theta = rep_vector(1.0 / N, N);
+    for (n in 1 : size(y)) {
+      int i = categorical_rng(theta);
+      int temp = y[n];
       y[n] = y[i];
       y[i] = temp;
-     }
-     return y;
+    }
+    return y;
   }
 }
 ```
 The name of the function must end in `_rng` because it uses other
 random functions internally.  This will restrict its usage to the
 transformed data and generated quantities block.  The code walks
-through the vector exchanging each item with another randomly chosen
+through an array of integers exchanging each item with another randomly chosen
 item, resulting in a uniformly drawn permutation of the integers
 `1:N`.^[The traditional approach is to walk through a vector and replace each item with a random element from the remaining elements, which is guaranteed to only move each item once. This was not done here as it'd require new categorical `theta` because Stan does not have a uniform discrete RNG built in.]
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes a piece of example code which was incorrect. Reported on the forums: https://discourse.mc-stan.org/t/not-working-function-in-stan-manual-s-permutation-rng/31415

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
