### PR TITLE
Minor fixes to beta function parameters and clarifying text for gamma distribution

### DIFF
--- a/src/functions-reference/positive_continuous_distributions.Rmd
+++ b/src/functions-reference/positive_continuous_distributions.Rmd
@@ -368,10 +368,12 @@ For a description of argument and return types, see section
 
 ### Probability density function
 
-If $\alpha \in \mathbb{R}^+$ and $\beta \in \mathbb{R}^+$, then for $y
+If the shape parameter $\alpha \in \mathbb{R}^+$ and the rate (or inverse scale) parameter $\beta \in \mathbb{R}^+$, then for $y
 \in \mathbb{R}^+$, \[ \text{Gamma}(y|\alpha,\beta) =
 \frac{\beta^{\alpha}}      {\Gamma(\alpha)} \, y^{\alpha - 1}
 \exp(-\beta \, y) . \]
+
+Under the shape and rate formulation of the Gamma distribution, $E(y) = \alpha/\beta$ and $\var(y) = \alpha/\beta^2$.
 
 ### Sampling statement
 

--- a/src/functions-reference/real-valued_basic_functions.Rmd
+++ b/src/functions-reference/real-valued_basic_functions.Rmd
@@ -1217,7 +1217,7 @@ Return the natural logarithm of the beta function applied to alpha and
 beta. The beta function, $\text{B}(\alpha,\beta)$, computes the
 normalizing constant for the beta distribution, and is defined for
 $\alpha > 0$ and $\beta > 0$. \[ \text{lbeta}(\alpha,\beta) = \log
-\Gamma(a) + \log \Gamma(b) - \log \Gamma(a+b) \] See section
+\Gamma(\alpha) + \log \Gamma(\beta) - \log \Gamma(\alpha+\beta) \] See section
 [appendix](#beta-appendix) for definition of $\text{B}(\alpha, \beta)$.
 `r since("2.0")`
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Builds locally -- see below
- [x ] New functions marked with `` `r since("VERSION")` ``
- [x ] Declare copyright holder and open-source license: see below

#### Summary

Minor improvements and fixes to documentation.

Note I get tex build errors which seem unrelated to my changes
> $ ./build.py 2 32
> render functions-reference as pdf
> output file: stan_docs/docs/2_32/functions-reference-2_32.pdf
> render functions-reference as html
> output dir: stan_docs/docs/2_32/functions-reference
> render reference-manual as pdf
> output file: stan_docs/docs/2_32/reference-manual-2_32.pdf
> render reference-manual as html
> output dir: stan_docs/docs/2_32/reference-manual
> render stan-users-guide as pdf
> Command Rscript -e "bookdown::render_book('index.Rmd', output_format='bookdown::pdf_book')" failed
> processing file: _main.Rmd
> output file: _main.knit.md
> ! TeX capacity exceeded, sorry [input stack size=10000]. \font@name -> \T1/bch/b/n/17.28
> l.16293 ...org/wiki/Amdahl\textquotesingle{}s_law}
> {Amdahl's
> Error: LaTeX failed to compile _main.tex. See https://yihui.org/tinytex/r/#debugging for debugging tips. See _main.log for more info.
> Execution halted
> Traceback (most recent call last):
> File "stan_docs/./build.py", line 129, in <module>
> main()
> File "stan_docs/./build.py", line 125, in main
> make_docs(docspath, stan_version, doc, formats)
> File "stan_docs/./build.py", line 56, in make_docs
> shexec(command)
> File "stan_docs/./build.py", line 36, in shexec
> raise Exception(ret.returncode)
> Exception: 1

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Michael Gilchrist



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
