### PR TITLE
Fix typo in gaussian-processes.Rmd

### DIFF
--- a/src/stan-users-guide/gaussian-processes.Rmd
+++ b/src/stan-users-guide/gaussian-processes.Rmd
@@ -609,7 +609,7 @@ GPs are a flexible class of priors and, as such, can represent a wide spectrum
 of functions.  For length scales below the minimum spacing of the covariates
 the GP likelihood plateaus.  Unless regularized by a prior, this flat
 likelihood induces considerable posterior mass at small length scales where the
-observation variance drops to zero and the functions supported by the GP being
+observation variance drops to zero and the functions supported by the GP begin
 to exactly interpolate between the input data.  The resulting posterior not
 only significantly overfits to the input data, it also becomes hard to
 accurately sample using Euclidean HMC.


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix a typo in gaussian-processes.Rmd (it said "being" instead of "begin").

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Adam Gorm Hoffmann.



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
