### PR TITLE
Add section on spaces in folder names to CmdStan installation troubleshooting

### DIFF
--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -299,6 +299,27 @@ To fix this, ensure you have followed the steps for adding the toolchain to your
 `PATH` and installing the additional utilities covered in the
 [configuration instructions](#windows)
 
+**Spaces in paths to CmdStan or model**
+
+Both `make` and `mingw32-make` can fail when dealing with files in folders
+with a space somewhere in their file path. Particularly on Windows, this can
+be an issue when CmdStan, or the models you are trying to build, are placed in
+the `One Drive` folder.
+
+Unfortunately, the errors created by this situation are not alwas informative.
+Some errors you may see are:
+
+```
+mingw32-make: *** INTERNAL: readdir: Invalid argument
+```
+```
+make: *** [make/program:50: x.hpp] Error 2
+```
+
+If the (fully-expanded) folder path to CmdStan or the model you are trying to
+build contains a space, we recommend trying a different location if you encounter
+any issues during building.
+
 
 ## C++ Toolchain {#cpp-toolchain}
 


### PR DESCRIPTION
Closes #650 

#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Adds a description of problems arising from having a space in the folder names of CmdStan or the model code

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
