### PR TITLE
Minor fix of math expression

### DIFF
--- a/src/stan-users-guide/custom-probability.Rmd
+++ b/src/stan-users-guide/custom-probability.Rmd
@@ -129,7 +129,7 @@ Z \sim \textsf{multivariate normal}\left(
 \\
 \rho & 1
 \end{bmatrix}
-]\right).
+\right).
 $$
 
 The following Stan program implements this function,


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Minor fix of math expression in `src/stan-users-guide/custom-probability.Rmd`.
Current version:

![image](https://github.com/stan-dev/docs/assets/216398/d83426ba-1914-428b-9765-1a0e8b8895fc)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

None. Just a minor bug fix.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
