### PR TITLE
Update CmdStan windows UCRT config

### DIFF
--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -440,6 +440,13 @@ pacman -Sy mingw-w64-x86_64-make          # 64-bit g++-8
 pacman -Sy mingw-w64-ucrt-x86_64-make     # 64-bit g++-10 (UCRT)
 ```
 
+If you have used the UCRT toolchain,some additional compilation flags will be needed for CmdStan.
+Navigate to the CmdStan/make directory and create a file called `local`. Add the following lines to the file:
+```
+CXXFLAGS += -Wno-nonnull -D_UCRT
+TBB_CXXFLAGS= -D_UCRT
+```
+
 ##### RTools42 & RTools43
 
 Both RTools42 & RTools43 provide 64-bit UCRT toolchains, where RTools42 provides g++-10 and
@@ -474,8 +481,8 @@ pacman -Sy mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-gcc
 Finally, some additional compilation flags will be needed for CmdStan. Navigate to
 the CmdStan/make directory and create a file called `local`. Add the following lines to the file:
 ```
-CXXFLAGS += -Wno-nonnull
-TBB_CXXFLAGS= -U__MSVCRT_VERSION__ -D__MSVCRT_VERSION__=0x0E00
+CXXFLAGS += -Wno-nonnull -D_UCRT
+TBB_CXXFLAGS= -D_UCRT
 ```
 
 __32-bit Builds__


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

This PR updates the recommended makeflags for RTools4.2+. The current flags work-around a bug in the UCRT toolchain where the toolchain is detected to be MSVCRT of a version not supporting particular extensions (causing compilation failures when building the TBB). 

The current approach is to "fake" a compatible MSVCRT version during the TBB build. We can instead use the `-D_UCRT` flag here

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
