### PR TITLE
Fix redirects to GP covariance functions page

### DIFF
--- a/docs/2_18/functions-reference/covariance.html
+++ b/docs/2_18/functions-reference/covariance.html
@@ -566,7 +566,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_19/functions-reference/covariance.html
+++ b/docs/2_19/functions-reference/covariance.html
@@ -570,7 +570,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_20/functions-reference/covariance.html
+++ b/docs/2_20/functions-reference/covariance.html
@@ -569,7 +569,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_21/functions-reference/covariance.html
+++ b/docs/2_21/functions-reference/covariance.html
@@ -687,7 +687,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2 number="5.12"><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_22/functions-reference/covariance.html
+++ b/docs/2_22/functions-reference/covariance.html
@@ -684,7 +684,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2 number="5.12"><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_23/functions-reference/covariance.html
+++ b/docs/2_23/functions-reference/covariance.html
@@ -583,7 +583,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_24/functions-reference/covariance.html
+++ b/docs/2_24/functions-reference/covariance.html
@@ -726,7 +726,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_25/functions-reference/covariance.html
+++ b/docs/2_25/functions-reference/covariance.html
@@ -714,7 +714,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2" number="5.12">
 <h2><span class="header-section-number">5.12</span> Covariance Functions</h2>

--- a/docs/2_26/functions-reference/covariance.html
+++ b/docs/2_26/functions-reference/covariance.html
@@ -616,7 +616,7 @@
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2">
 <h2><span class="header-section-number">5.13</span> Covariance functions</h2>

--- a/docs/2_27/functions-reference/covariance.html
+++ b/docs/2_27/functions-reference/covariance.html
@@ -761,7 +761,7 @@ div.csl-indent {
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2" number="5.13">
 <h2><span class="header-section-number">5.13</span> Covariance functions</h2>

--- a/docs/2_28/functions-reference/covariance.html
+++ b/docs/2_28/functions-reference/covariance.html
@@ -784,7 +784,7 @@ div.csl-indent {
             <section class="normal" id="section-">
 
 <div>
-This is an old version, <a href="https://mc-stan.org/docs/functions-reference/covariance.html">view current version</a>.
+This is an old version, <a href="https://mc-stan.org/docs/functions-reference/gaussian-process-covariance-functions.html">view current version</a>.
 </div>
 <div id="covariance" class="section level2" number="6.13">
 <h2><span class="header-section-number">6.13</span> Covariance functions</h2>


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

This page was renamed which broke older links to the new version. Reported by @jsocolar on slack

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
