### PR TITLE
Update dead link to RTools43

### DIFF
--- a/src/cmdstan-guide/installation.Rmd
+++ b/src/cmdstan-guide/installation.Rmd
@@ -452,7 +452,7 @@ RTools43 provides g++-12. The installation/configuration is identical for both t
 Download the installer for your preferred toolchain and complete the prompts for installation:
 
  - [RTools42](https://cran.r-project.org/bin/windows/Rtools/rtools42/files/rtools42-5355-5357.exe)
- - [RTools43](https://cran.r-project.org/bin/windows/Rtools/rtools43/files/rtools43-5550-5548.exe)
+ - [RTools43](https://cran.r-project.org/bin/windows/Rtools/rtools43/files/rtools43-5863-5818.exe)
 
 Next, you need to add the toolchain directory to your `PATH` variable. Add the appropriate lines
 from below:


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Link to RTools43 is dead now that a new version has been released. Request has also been sent to CRAN for a generic or fixed-version download link.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
