### PR TITLE
Remove versions from some links

### DIFF
--- a/src/cmdstan-guide/parallelization.Rmd
+++ b/src/cmdstan-guide/parallelization.Rmd
@@ -59,7 +59,7 @@ with 8 total threads available:
 ## Multi-processing with MPI
 
 In order to use multi-processing with MPI in a Stan model, the models must be
-rewritten to use the [`map_rect` function](https://mc-stan.org/docs/2_26/functions-reference/functions-map.html). By using MPI, the model can be parallelized across multiple cores or a cluster. MPI with Stan is supported on MacOS and Linux.
+rewritten to use the [`map_rect` function](https://mc-stan.org/docs/functions-reference/functions-map.html). By using MPI, the model can be parallelized across multiple cores or a cluster. MPI with Stan is supported on MacOS and Linux.
 
 ### Dependencies
 

--- a/src/stan-users-guide/user-functions.Rmd
+++ b/src/stan-users-guide/user-functions.Rmd
@@ -405,7 +405,7 @@ function (`_lpmf`) must be discrete (integer or integer array).
 ## Overloading functions
 
 As described in the [reference
-manual](https://mc-stan.org/docs/2_28/reference-manual/function-names.html)
+manual](https://mc-stan.org/docs/reference-manual/function-names.html)
 function overloading is permitted in Stan, beginning in version 2.29.
 
 This means multiple functions can be defined with the same name as long as

--- a/src/stan-users-guide/using-stanc.Rmd
+++ b/src/stan-users-guide/using-stanc.Rmd
@@ -129,7 +129,7 @@ There are five kinds of errors emitted by stanc3
    Error: file 'notfound.stan' not found or cannot be opened
    ```
 2. Syntactic errors occur whenever a program violates the Stan language's
-   [syntax](https://mc-stan.org/docs/2_27/reference-manual/language-syntax.html)
+   [syntax](https://mc-stan.org/docs/reference-manual/language-syntax.html)
    requirements. There are three kinds of errors within syntax errors; "lexing"
    errors mean that the input was unable to be read properly on the character
    level, "include" errors which occur when the `#include` directive fails, and


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

A few cross-docs links had a version baked in when it was not needed.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
