### PR TITLE
Update documentation mentions of pRNG

### DIFF
--- a/src/cmdstan-guide/external_code.qmd
+++ b/src/cmdstan-guide/external_code.qmd
@@ -193,8 +193,8 @@ on their signatures if used in external C++.
 
 - RNGs must end with `_rng`. They will be passed a "base RNG object" as the
   second to last argument, before the pointer to the ostream. We recommend
-  making this a template, since it may change, but at the moment it is always a
-  `boost::random::ecuyer1988` object.
+  making this a template, since it may change. This is currently a
+  `stan::rng_t` object (a type alias to `boost::rng::mixmax`).
 - Functions which edit the `target` directly must end with `_lp` and will be
   passed a reference to `lp__` and a reference to a `stan::math::accumulator`
   object as the final parameters before the ostream pointer. They are also

--- a/src/reference-manual/reproducibility.qmd
+++ b/src/reference-manual/reproducibility.qmd
@@ -56,3 +56,16 @@ nice discussion of the issues and how to control reproducibility in
 Intel's proprietary compiler by @CordenKreitzer:2014.
 
 
+## Notable changes across versions
+
+As noted above, there is no guarantee that the same results will be reproducible
+between two different versions of Stan, even if the same settings and environment are used.
+
+However, there are occassionally notable changes which would affect many if not all users,
+and these are noted here. The absence of a version from this list still *does not*
+guarantee exact reproducibility between it and other versions.
+
+- Stan 2.28 changed the default chain ID for MCMC from `0` to `1`. Users who had set a seed
+  but not a chain ID would observe completely different outputs.
+- Stan 2.35 changed the default pseudo-random number generator used by the Stan algorithms.
+  There is no relationship between seeds in versions pre-2.35 and version 2.35 and on.


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally 
- [x] New functions marked with `` `r since("VERSION")` ``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Doc updates following https://github.com/stan-dev/stan/pull/3264; we no longer use `boost::random::ecuyer1988`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
