### PR TITLE
Remove reference to outdated BITS=32 make variable

### DIFF
--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -478,11 +478,6 @@ Execute the below commands to install the needed dependencies:
 pacman -Sy mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-gcc
 ```
 
-__32-bit Builds__
-
-CmdStan defaults to a 64-bit build. On a 32-bit operating system, you must specify
-the make variable `BIT=32` as part of the `make` command, described in the next section.
-
 [^1]:
 To open a Windows command shell, first open the __Start Menu__,
 (usually in the lower left of the screen), select option __All Programs__,
@@ -561,9 +556,9 @@ set the makefile variable `STAN_OPENCL` to `TRUE`:
 ```
 Makefile variables can also be set by creating a file named `local` in the
 CmdStan `make` subdirectory which contains a list of `<VARIABLE>=<VALUE>` pairs,
-one per line.   For example, if you are working on a 32-bit machine,
-you would put the line `BIT=32` into the file `<cmdstan-home>/make/local`
-so that all CmdStan programs and Stan models compile properly.
+one per line.   For example, to get the same effect as the above command
+every time, you would put the line `STAN_OPENCL=TRUE` into the file
+`<cmdstan_home>/make/local`.
 
 The complete set of Makefile variables can be found in file
 `<cmdstan-home>/cmdstan/stan/lib/stan_math/make/compiler_flags`.


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

See https://github.com/stan-dev/math/issues/3043 -- this variable does not do anything in the current build system.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Simons Foundation

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
