### PR TITLE
Fix discrete_range_rng's return type, link to vectorization doc

### DIFF
--- a/src/functions-reference/bounded_discrete_distributions.qmd
+++ b/src/functions-reference/bounded_discrete_distributions.qmd
@@ -659,12 +659,14 @@ The log of the discrete range complementary cumulative distribution function
 for the given y, lower and upper bounds.
 {{< since 2.26 >}}
 
-<!-- int; discrete_range_rng; (ints l, ints u); -->
-\index{{\tt \bfseries discrete\_range\_rng }!{\tt (ints l, ints u): int}|hyperpage}
+<!-- ints; discrete_range_rng; (ints l, ints u); -->
+\index{{\tt \bfseries discrete\_range\_rng }!{\tt (ints l, ints u): ints}|hyperpage}
 
-`int` **`discrete_range_rng`**`(ints l, ints u)`<br>\newline
+`ints` **`discrete_range_rng`**`(ints l, ints u)`<br>\newline
 Generate a discrete variate between the given lower and upper bounds;
 may only be used in transformed data and generated quantities blocks.
+For a description of argument and return types, see section
+[vectorized PRNG functions](conventions_for_probability_functions.qmd#prng-vectorization).
 {{< since 2.26 >}}
 
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

First reported on the forums: https://discourse.mc-stan.org/t/understanding-of-discrete-range-rng-with-the-ints/34763/2

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
