### PR TITLE
Fix link text in ODE argument section

### DIFF
--- a/src/functions-reference/higher-order_functions.qmd
+++ b/src/functions-reference/higher-order_functions.qmd
@@ -299,7 +299,7 @@ ODE solve function call.
 
 The arguments to the ODE solvers in both the stiff and non-stiff solvers are the
 same. The arguments to the adjoint ODE solver are different; see
-[Arguments to the adjoint ODE solvers](#adjoint-sensitivity-solver).
+[Arguments to the adjoint ODE solver](#adjoint-sensitivity-solver).
 
 *   *`ode`*: ODE system function,
 
@@ -333,7 +333,7 @@ or functions of parameters or transformed parameters.
 
 The arguments to the adjoint ODE solver are different from those for
 the other functions (for those see
-[Arguments to the adjoint ODE solvers](#forward-sensitivity-solver)).
+[Arguments to the ODE solvers](#forward-sensitivity-solver)).
 
 *   *`ode`*: ODE system function,
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

The cross-links between these sections both used the same text for "see also" links, despite linking to different things

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
