### PR TITLE
Update Windows doc to use RTools44, add ARM64 instructions

### DIFF
--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -396,34 +396,49 @@ g++ --version
 make --version
 ```
 
-CmdStan is known compatible with the RTools43 toolchain. The toolchain will require
+CmdStan is known compatible with the RTools44 toolchain. The toolchain will require
 updating your `PATH` variable, See [these instructions](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/)
 for details on changing the `PATH` if you are unfamiliar. The following instructions will assume that the default installation
 directory was used, so be sure to update the paths accordingly if you have chosen a different
 directory.
 
 
-##### RTools43
+##### RTools44
 
 All required utilities (e.g., `make`, `g++`) for compiling and running CmdStan models on Windows are
-provided by the RTools43 toolchain from the R Project. Installation steps are provided below,
-and for more technical details on the toolchain refer to the [R Project documentation](https://cran.r-project.org/bin/windows/Rtools/rtools43/rtools.html).
+provided by the RTools44 toolchain from the R Project. Installation steps are provided below,
+and for more technical details on the toolchain refer to the [R Project documentation](https://cran.r-project.org/bin/windows/Rtools/rtools44/rtools.html).
+
+The R Project provides RTools44 for both Intel/AMD 64-bit (x86_64) and ARM 64-bit (aarch64) systems.
+If you are unsure which to use, then you can check by going to the Windows Settings, selecting the 'System' menu and then the 'About' option.
+If the 'System Type' field lists 'ARM-based processor', then you should follow the ARM64 instructions below.
 
 Note that the toolchain is only available for 64-bit systems, and uses the new Universal C Runtime (UCRT).
 UCRT is only natively supported on Windows 10 and newer, older systems will require a
 [Microsoft update](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).
 
-###### Installation
+###### Installation - Intel/AMD 64-bit (x86_64)
 
 Download the installer and complete the prompts for installation:
 
- - [RTools43](https://cran.r-project.org/bin/windows/Rtools/rtools43/files/rtools43-5958-5975.exe)
+ - [RTools44](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-6104-6039.exe)
 
-Next, you need to add the toolchain directory to your `PATH` variable. Add the appropriate lines
-from below:
+Next, you need to add the toolchain directory to your `PATH` variable:
 ```
-C:\rtools43\usr\bin
-C:\rtools43\x86_64-w64-mingw32.static.posix\bin
+C:\rtools44\usr\bin
+C:\rtools44\x86_64-w64-mingw32.static.posix\bin
+```
+
+###### Installation - ARM 64-bit (arm64/aarch64)
+
+Download the installer and complete the prompts for installation:
+
+ - [RTools44 - ARM64](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-aarch64-6104-6039.exe)
+
+Next, you need to add the toolchain directory to your `PATH` variable:
+```
+C:\rtools44-aarch64\usr\bin
+C:\rtools44-aarch64\aarch64-w64-mingw32.static.posix\bin
 ```
 
 ## Using GNU Make {#gnu-make}


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

With the R4.0 release, the Rtools44 toolchain has also been release, including a stable ARM64 version. This PR updates the doc to recommend the use of RTools44, and also adds instructions for using the ARM64 toolchain on windows

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
