### PR TITLE
Document Wiener overloads

### DIFF
--- a/gen_index.py
+++ b/gen_index.py
@@ -54,7 +54,7 @@ def write_index_page(index):
 
             escaped_name = name.replace("\\", "\\\\").replace("*", "\\*")
             f.write(f"**{escaped_name}**:\n\n")
-            for link, entry in sorted(links, key=lambda x: x[1].lower()):
+            for link, entry in sorted(links, key=lambda x: x[1].lower() + x[0]):
                 f.write(f" - [{entry}]({link})\n")
             f.write("\n\n")
 

--- a/gen_index.py
+++ b/gen_index.py
@@ -54,7 +54,7 @@ def write_index_page(index):
 
             escaped_name = name.replace("\\", "\\\\").replace("*", "\\*")
             f.write(f"**{escaped_name}**:\n\n")
-            for link, entry in sorted(links):
+            for link, entry in sorted(links, key=lambda x: x[1].lower()):
                 f.write(f" - [{entry}]({link})\n")
             f.write("\n\n")
 

--- a/src/functions-reference/functions_index.qmd
+++ b/src/functions-reference/functions_index.qmd
@@ -10,8 +10,8 @@ pagetitle: Alphabetical Index
 **abs**:
 
  - [`(complex z) : real`](complex-valued_basic_functions.qmd#index-entry-00d0fd704b516cbdb1c9d8cfdceb177a76481cc4)
- - [`(T x) : T`](real-valued_basic_functions.qmd#index-entry-c197d7c04ea9bf23cf252f2092111b3c5aadd02d)
  - [`(T x) : T`](integer-valued_basic_functions.qmd#index-entry-c197d7c04ea9bf23cf252f2092111b3c5aadd02d)
+ - [`(T x) : T`](real-valued_basic_functions.qmd#index-entry-c197d7c04ea9bf23cf252f2092111b3c5aadd02d)
 
 
 **acos**:
@@ -2567,10 +2567,10 @@ pagetitle: Alphabetical Index
  - [`(row_vector x) : row_vector`](matrix_operations.qmd#index-entry-7fa245ebd36b8195ee47b5cf42158c3936625d93)
  - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-0e7a932586415d9249383de3efe664eb105f4a4f)
  - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-f9f5c0ef9c18e80c24aa789a90b7d1253096fa3a)
- - [`(T x) : T`](matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
- - [`(T x) : T`](complex_matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
  - [`(T x) : T`](complex-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
+ - [`(T x) : T`](complex_matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
  - [`(T x) : T`](integer-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
+ - [`(T x) : T`](matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
  - [`(T x) : T`](real-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
  - [`(vector x) : vector`](matrix_operations.qmd#index-entry-8339baafb56b84ffc02ddc234752ab1f7a46e1e3)
  - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-0dea3575356afb28b43da9a9985361d5ba7e1c84)
@@ -3278,8 +3278,8 @@ pagetitle: Alphabetical Index
  - [`(complex_row_vector x) : int`](complex_matrix_operations.qmd#index-entry-dd6512340d46b06fe64606e36622bf23ed255eab)
  - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-4a14d6b215559d7664aabfafde37e9153206b209)
  - [`(int x) : int`](integer-valued_basic_functions.qmd#index-entry-cc587d014dd8cd99986939af8ad1854a3c3425f0)
- - [`(matrix x) : int`](matrix_operations.qmd#index-entry-69098855a034f282c0294e1c6c21cded79ec8a3c)
  - [`(matrix x) : int`](complex_matrix_operations.qmd#index-entry-69098855a034f282c0294e1c6c21cded79ec8a3c)
+ - [`(matrix x) : int`](matrix_operations.qmd#index-entry-69098855a034f282c0294e1c6c21cded79ec8a3c)
  - [`(real x) : int`](integer-valued_basic_functions.qmd#index-entry-f9c96384668fa7a7880511c2c0ad2558be24e0a4)
  - [`(row_vector x) : int`](matrix_operations.qmd#index-entry-f449c3a25c74efefc2c1462cf914a52a4050d575)
  - [`(vector x) : int`](matrix_operations.qmd#index-entry-9b99cb12fadc8373556db600c949cc44b43fe907)

--- a/src/functions-reference/functions_index.qmd
+++ b/src/functions-reference/functions_index.qmd
@@ -10,8 +10,8 @@ pagetitle: Alphabetical Index
 **abs**:
 
  - [`(complex z) : real`](complex-valued_basic_functions.qmd#index-entry-00d0fd704b516cbdb1c9d8cfdceb177a76481cc4)
- - [`(T x) : T`](integer-valued_basic_functions.qmd#index-entry-c197d7c04ea9bf23cf252f2092111b3c5aadd02d)
  - [`(T x) : T`](real-valued_basic_functions.qmd#index-entry-c197d7c04ea9bf23cf252f2092111b3c5aadd02d)
+ - [`(T x) : T`](integer-valued_basic_functions.qmd#index-entry-c197d7c04ea9bf23cf252f2092111b3c5aadd02d)
 
 
 **acos**:
@@ -29,10 +29,10 @@ pagetitle: Alphabetical Index
 **add_diag**:
 
  - [`(complex_matrix m, complex_real d) : complex_matrix`](complex_matrix_operations.qmd#index-entry-1bd31f2687a12296c53d88aedd4fe7b91be42e6b)
- - [`(complex_matrix m, complex_vector d) : complex_matrix`](complex_matrix_operations.qmd#index-entry-c75a27fd3abf5459a2683dc6261be6c0045b71d6)
  - [`(complex_matrix m, complex_row_vector d) : complex_matrix`](complex_matrix_operations.qmd#index-entry-ebc82f3647c3357e9ff2d0c3de2f5996ac435a22)
- - [`(matrix m, row_vector d) : matrix`](matrix_operations.qmd#index-entry-6c34e1496216d483a0c9876713871db5b36de2b1)
+ - [`(complex_matrix m, complex_vector d) : complex_matrix`](complex_matrix_operations.qmd#index-entry-c75a27fd3abf5459a2683dc6261be6c0045b71d6)
  - [`(matrix m, real d) : matrix`](matrix_operations.qmd#index-entry-6c3894d5b0c4aa6fcae69f294bd4a39e91e3731b)
+ - [`(matrix m, row_vector d) : matrix`](matrix_operations.qmd#index-entry-6c34e1496216d483a0c9876713871db5b36de2b1)
  - [`(matrix m, vector d) : matrix`](matrix_operations.qmd#index-entry-fd1fe55afe2b42fa662d88b9e836e27f40aed6ed)
 
 
@@ -54,37 +54,37 @@ pagetitle: Alphabetical Index
 
 **append_col**:
 
+ - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-6d9a3c740a41d03e1694a8957fc0686db16578c7)
+ - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-ffc1159a99f60f1f9ed57275f62abef2a8565af2)
  - [`(complex_matrix x, complex_vector y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-3cdea5abd8dcc4f4aa3a63ec4b57e3beb1e548d1)
  - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-435f75dc018a8af24be3ee5ac716757fc6ed0919)
- - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-6d9a3c740a41d03e1694a8957fc0686db16578c7)
+ - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-e38bc5278f6ed1cde644188c8eb17161f960454d)
  - [`(complex_vector x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-925808fc8edc656698d2fa5a95c71e4392b64386)
  - [`(complex_vector x, complex_vector y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a7e682a73b7b4c9c5e762266afcff98336e95763)
- - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-e38bc5278f6ed1cde644188c8eb17161f960454d)
- - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-ffc1159a99f60f1f9ed57275f62abef2a8565af2)
- - [`(matrix x, vector y) : matrix`](matrix_operations.qmd#index-entry-147e13862145f964e1cbb7fcc77a67089a7e5e34)
- - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-21151b3cbeecb129181ef54f899636e705e64a59)
- - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-3bee320543341ea29edfb9d04aca5cc49f8e0b95)
- - [`(vector x, vector y) : matrix`](matrix_operations.qmd#index-entry-58eedcbe1e2b7f299a093b3640fbf33c5ed668a7)
- - [`(vector x, matrix y) : matrix`](matrix_operations.qmd#index-entry-864b816280933455ecf6e923c13d45129a29b0fd)
  - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-9e081ce392909a0df24bb36f03bfa797bed61afc)
+ - [`(matrix x, vector y) : matrix`](matrix_operations.qmd#index-entry-147e13862145f964e1cbb7fcc77a67089a7e5e34)
  - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-c2a28748bc8f89b100ba5a447e6a37085a0c322f)
+ - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-3bee320543341ea29edfb9d04aca5cc49f8e0b95)
+ - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-21151b3cbeecb129181ef54f899636e705e64a59)
+ - [`(vector x, matrix y) : matrix`](matrix_operations.qmd#index-entry-864b816280933455ecf6e923c13d45129a29b0fd)
+ - [`(vector x, vector y) : matrix`](matrix_operations.qmd#index-entry-58eedcbe1e2b7f299a093b3640fbf33c5ed668a7)
 
 
 **append_row**:
 
- - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-101152cf279176e6d126b58acb513a382b3076db)
- - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-8140228bb8f902ae61c5e8eba43e81e6d32de7bd)
- - [`(complex_matrix x, complex_row_vector y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a0c350c64c953d5aa3a9de44bc62448e1b90233d)
  - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-a9fd96b44e573f1bb61f0cf8266f4bdc7a805dd3)
  - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-ca4bcfd187ccd1d2f4f0816dfc7f2b31f95ff4b2)
+ - [`(complex_matrix x, complex_row_vector y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a0c350c64c953d5aa3a9de44bc62448e1b90233d)
  - [`(complex_row_vector x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-cbbd35ff37b9d41a2c66dbb60739e4b40a3b2c92)
  - [`(complex_row_vector x, complex_row_vector y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-d3f8a5fb9c0e574f1b8fc41e58b9ff4d768b1316)
+ - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-8140228bb8f902ae61c5e8eba43e81e6d32de7bd)
+ - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-101152cf279176e6d126b58acb513a382b3076db)
  - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-135048f5cff906d2164940e5b4b34af8be6d9972)
  - [`(matrix x, row_vector y) : matrix`](matrix_operations.qmd#index-entry-1f14ca719bab4b3d6eff9ae371f10a5fac48b85c)
- - [`(row_vector x, matrix y) : matrix`](matrix_operations.qmd#index-entry-54b2d5adfa559ab3f257ab5acd8f7f57c4fafbf9)
- - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-626869953f524fd6120faadc1ed9dcdb8f710167)
- - [`(row_vector x, row_vector y) : matrix`](matrix_operations.qmd#index-entry-6f6580337b50792274a5b4740260362421589d97)
  - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-be0707e02550507f8665c2fa85d337275029a3c5)
+ - [`(row_vector x, matrix y) : matrix`](matrix_operations.qmd#index-entry-54b2d5adfa559ab3f257ab5acd8f7f57c4fafbf9)
+ - [`(row_vector x, row_vector y) : matrix`](matrix_operations.qmd#index-entry-6f6580337b50792274a5b4740260362421589d97)
+ - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-626869953f524fd6120faadc1ed9dcdb8f710167)
  - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-f406895b07b910f47d6bd89b7d603c711582be11)
 
 
@@ -158,20 +158,20 @@ pagetitle: Alphabetical Index
 
  - [`(array[] int y | matrix x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-3c4e9f4b1e229095991ef7d66e815550e6189de8)
  - [`(array[] int y | matrix x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-5ba40a905c796c1bcd54602e2cdde64d36486f54)
- - [`(array[] int y | row_vector x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-616a93c521e26ed8b747183681c8f77775ffad47)
- - [`(int y | matrix x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-8595b1aadcd41c4266263ddfa5529f3381f42c02)
- - [`(int y | matrix x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-b84bfdcb0924789b419a611e996c6185d4c9ec71)
  - [`(array[] int y | row_vector x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-e6ed6ee376ada4610e458b39eb40199e201a1752)
+ - [`(array[] int y | row_vector x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-616a93c521e26ed8b747183681c8f77775ffad47)
+ - [`(int y | matrix x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-b84bfdcb0924789b419a611e996c6185d4c9ec71)
+ - [`(int y | matrix x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-8595b1aadcd41c4266263ddfa5529f3381f42c02)
 
 
 **bernoulli_logit_glm_lupmf**:
 
- - [`(array[] int y | row_vector x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-06917600c21e8a8c04a19d2e00412d5adc619330)
- - [`(int y | matrix x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-09934df75edb200a53b9e3f261e389a5c908bb0e)
  - [`(array[] int y | matrix x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-171d0ba3be3d570d3167c621b3a6e7bac0f34b49)
- - [`(int y | matrix x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-58e5cd13a2585a62b0a4305dfb70b2276419bd31)
  - [`(array[] int y | matrix x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-75e3b277f495a675db21144dfd54403c5b61e4b1)
  - [`(array[] int y | row_vector x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-75fe439a6c3fdf76668cd7afcb6fcc6d7d2aee4e)
+ - [`(array[] int y | row_vector x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-06917600c21e8a8c04a19d2e00412d5adc619330)
+ - [`(int y | matrix x, real alpha, vector beta) : real`](binary_distributions.qmd#index-entry-58e5cd13a2585a62b0a4305dfb70b2276419bd31)
+ - [`(int y | matrix x, vector alpha, vector beta) : real`](binary_distributions.qmd#index-entry-09934df75edb200a53b9e3f261e389a5c908bb0e)
 
 
 **bernoulli_logit_glm_rng**:
@@ -218,15 +218,15 @@ pagetitle: Alphabetical Index
 
 **bessel_second_kind**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-7d09ab04cf9e5ad369f0475cf89c0dcf0e6cf137)
  - [`(int v, real x) : real`](real-valued_basic_functions.qmd#index-entry-a76f46f2143eed84250e51f4f9fa21abf7ff8085)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-7d09ab04cf9e5ad369f0475cf89c0dcf0e6cf137)
 
 
 **beta**:
 
- - [sampling statement](continuous_distributions_on_0_1.qmd#index-entry-ed6b0e2a1365933147e892aab802b3da10b2bb6d)
  - [`(real alpha, real beta) : real`](real-valued_basic_functions.qmd#index-entry-bbec535fbcce7c57b2dd2cc189383f0c180038ed)
  - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-faea3c6dc569671c76ab57211c00ebac2394742c)
+ - [sampling statement](continuous_distributions_on_0_1.qmd#index-entry-ed6b0e2a1365933147e892aab802b3da10b2bb6d)
 
 
 **beta_binomial**:
@@ -326,8 +326,8 @@ pagetitle: Alphabetical Index
 
 **binary_log_loss**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-05d751372242ac11c1c7356d09fb0341276b897c)
  - [`(int y, real y_hat) : real`](real-valued_basic_functions.qmd#index-entry-44fff3495ce5cd36ebde4587e802cb7bdc795794)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-05d751372242ac11c1c7356d09fb0341276b897c)
 
 
 **binomial**:
@@ -362,22 +362,22 @@ pagetitle: Alphabetical Index
 
 **binomial_logit_glm_lpmf**:
 
- - [`(array[] int n | array[] int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-1882ad2cd7ca87f3d1050d5be18f2adcc431d794)
- - [`(int n | int N, matrix x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-3da9351d4d4f1762941c69259fcfddf39dd65eae)
  - [`(array[] int n | array[] int N, matrix x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-3f85893b1fea02de309015929662b0b20beb9309)
- - [`(int n | int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-a7a84a22f1a74964827e7e3c3c2ecb0233e5cf37)
+ - [`(array[] int n | array[] int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-1882ad2cd7ca87f3d1050d5be18f2adcc431d794)
  - [`(array[] int n | array[] int N, row_vector x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-e1b1936f95d710de4ad0682cbf085a530908d39a)
  - [`(array[] int n | array[] int N, row_vector x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-e38992f8d67e6ef5ce4e08abdfb07fe5ff1d3c9a)
+ - [`(int n | int N, matrix x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-3da9351d4d4f1762941c69259fcfddf39dd65eae)
+ - [`(int n | int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-a7a84a22f1a74964827e7e3c3c2ecb0233e5cf37)
 
 
 **binomial_logit_glm_lupmf**:
 
- - [`(array[] int n | array[] int N, row_vector x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-428627db76fccf914ceaefa4cd5884bd131556b9)
- - [`(int n | int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-588f750b18cf5987a93c0022ecc43c232efc3e24)
- - [`(array[] int n | array[] int N, row_vector x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-7d6e3169c60256f12c03411a7509e0370a1ee157)
- - [`(array[] int n | array[] int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-9889fa94aac823796e6949b79108363bfbbbaa9d)
- - [`(int n | int N, matrix x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-de178183d4185e13aa59ffee44cc49a8ba2dc7e9)
  - [`(array[] int n | array[] int N, matrix x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-f45f2f92b4005c55ad8f5cdd2285c9708fefe806)
+ - [`(array[] int n | array[] int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-9889fa94aac823796e6949b79108363bfbbbaa9d)
+ - [`(array[] int n | array[] int N, row_vector x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-428627db76fccf914ceaefa4cd5884bd131556b9)
+ - [`(array[] int n | array[] int N, row_vector x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-7d6e3169c60256f12c03411a7509e0370a1ee157)
+ - [`(int n | int N, matrix x, real alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-de178183d4185e13aa59ffee44cc49a8ba2dc7e9)
+ - [`(int n | int N, matrix x, vector alpha, vector beta) : real`](bounded_discrete_distributions.qmd#index-entry-588f750b18cf5987a93c0022ecc43c232efc3e24)
 
 
 **binomial_logit_lpmf**:
@@ -430,18 +430,18 @@ pagetitle: Alphabetical Index
 
 **categorical_logit_glm_lpmf**:
 
- - [`(int y | row_vector x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-4e1f97ef06a17d796b0a7cc5ae22003b03f95401)
  - [`(array[] int y | matrix x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-512bbe1dc00cc3ef23d8272ec1c0da56105f1c42)
  - [`(array[] int y | row_vector x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-8f756acaa498908962c53d1a6b0af17598fd8524)
  - [`(int y | matrix x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-b41f55e8856f7805a26e7a2ee183d028df87f769)
+ - [`(int y | row_vector x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-4e1f97ef06a17d796b0a7cc5ae22003b03f95401)
 
 
 **categorical_logit_glm_lupmf**:
 
  - [`(array[] int y | matrix x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-09da9504e8676f6b35327c85d13771d63f77b83b)
- - [`(int y | row_vector x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-3e5402103e17dd48bb2625e6a2b76c48782a1a72)
  - [`(array[] int y | row_vector x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-518462f77e8ba90187fbc7302cb54236a0c8b333)
  - [`(int y | matrix x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-866be3d0f99507bddabbbe0652cce251858d2c37)
+ - [`(int y | row_vector x, vector alpha, matrix beta) : real`](bounded_discrete_distributions.qmd#index-entry-3e5402103e17dd48bb2625e6a2b76c48782a1a72)
 
 
 **categorical_logit_lpmf**:
@@ -566,8 +566,8 @@ pagetitle: Alphabetical Index
 
 **choose**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-ed9d9ccf90b8976a4cc2b40babee7c60d4807087)
  - [`(int x, int y) : int`](real-valued_basic_functions.qmd#index-entry-fd4d9124ce89bf38a7ca1601e28f14947fcae3ba)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-ed9d9ccf90b8976a4cc2b40babee7c60d4807087)
 
 
 **col**:
@@ -579,30 +579,30 @@ pagetitle: Alphabetical Index
 **cols**:
 
  - [`(complex_matrix x) : int`](complex_matrix_operations.qmd#index-entry-22eb74ccaa0e3cbd1875a10b1d25e448aaca1078)
- - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-2926894bc112a2f76fc88ec0d1b66ca72f6907ab)
  - [`(complex_row_vector x) : int`](complex_matrix_operations.qmd#index-entry-a3afb9b9b85c96fcbb2ceccffe8220cdf6930ee0)
+ - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-2926894bc112a2f76fc88ec0d1b66ca72f6907ab)
+ - [`(matrix x) : int`](matrix_operations.qmd#index-entry-f399f6ffab24708be4ff867cbaef541158fc00bf)
  - [`(row_vector x) : int`](matrix_operations.qmd#index-entry-417aeef6881030f640a4ea077e02335739bf0e3e)
  - [`(vector x) : int`](matrix_operations.qmd#index-entry-8113ac540f4cc3aa182c3afcfa5d1665778f7fd9)
- - [`(matrix x) : int`](matrix_operations.qmd#index-entry-f399f6ffab24708be4ff867cbaef541158fc00bf)
 
 
 **columns_dot_product**:
 
- - [`(complex_vector x, complex_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-73c167059a6fb3ee21b48776d84d7c14cd6b6b9a)
- - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-aee28160ebf0573187fba8d1b9917b490dfd47cd)
  - [`(complex_matrix x, complex_matrix y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-c0a3895052c73d4b7553b42dfbcf4ceee17d6ebd)
- - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-4758c18c6242ed86d28834ea3c356de1d5e22b86)
+ - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-aee28160ebf0573187fba8d1b9917b490dfd47cd)
+ - [`(complex_vector x, complex_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-73c167059a6fb3ee21b48776d84d7c14cd6b6b9a)
  - [`(matrix x, matrix y) : row_vector`](matrix_operations.qmd#index-entry-758593f0bee7c0421df7fc503237288851879118)
+ - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-4758c18c6242ed86d28834ea3c356de1d5e22b86)
  - [`(vector x, vector y) : row_vector`](matrix_operations.qmd#index-entry-7b3a4d9f9236657fd6d5970b8840e4a2e7e176bf)
 
 
 **columns_dot_self**:
 
- - [`(complex_vector x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-25320510319f7efaed97fc7327bcb3481a1fd055)
  - [`(complex_matrix x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-499a93465efa4feea0949bffdec099ac446865be)
  - [`(complex_row_vector x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-5a3c0ca6ac56df87695d6d53c5ed41bd076db1bf)
- - [`(row_vector x) : row_vector`](matrix_operations.qmd#index-entry-258f64fdc22d8a6e1012cfa375d94222962c3add)
+ - [`(complex_vector x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-25320510319f7efaed97fc7327bcb3481a1fd055)
  - [`(matrix x) : row_vector`](matrix_operations.qmd#index-entry-664db2ea209dd84f3f62d813817a0be019ff3afb)
+ - [`(row_vector x) : row_vector`](matrix_operations.qmd#index-entry-258f64fdc22d8a6e1012cfa375d94222962c3add)
  - [`(vector x) : row_vector`](matrix_operations.qmd#index-entry-f0c5a660d69d25748bdafa9cda98ee0cfa190cbe)
 
 
@@ -620,14 +620,14 @@ pagetitle: Alphabetical Index
 
 **complex_schur_decompose_u**:
 
- - [`(matrix A) : complex_matrix`](complex_matrix_operations.qmd#index-entry-b169076e82ada507c5c30f36fe4a5bda58af9e0a)
  - [`(complex_matrix A) : complex_matrix`](complex_matrix_operations.qmd#index-entry-fdc477180371e8366e3a46dc88f3875f088907c8)
+ - [`(matrix A) : complex_matrix`](complex_matrix_operations.qmd#index-entry-b169076e82ada507c5c30f36fe4a5bda58af9e0a)
 
 
 **conj**:
 
- - [`(Z z) : Z`](complex-valued_basic_functions.qmd#index-entry-17692d922273aaba0c5317617aab6585dda28bfa)
  - [`(complex z) : complex`](complex-valued_basic_functions.qmd#index-entry-bd2ae18bb245caf34d1b2f12b3883c47d8aa7e0a)
+ - [`(Z z) : Z`](complex-valued_basic_functions.qmd#index-entry-17692d922273aaba0c5317617aab6585dda28bfa)
 
 
 **cos**:
@@ -645,11 +645,11 @@ pagetitle: Alphabetical Index
 **cov_exp_quad**:
 
  - [`(array[] real x, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-1ba90fc13ad6ba28ca73fc3b94b0a65af09669f8)
- - [`(vectors x1, vectors x2, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-70b15de7e29e4e64f05ca3fc552da349d4a66c1f)
- - [`(row_vectors x, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-92099ecf9309d8f643e455cb6e3f79c985d35cb1)
  - [`(array[] real x1, array[] real x2, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-95bfeb84294b276027c24d3f8856560234423e7c)
+ - [`(row_vectors x, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-92099ecf9309d8f643e455cb6e3f79c985d35cb1)
  - [`(row_vectors x1, row_vectors x2, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-c05741ae8e35d6b11a03c0098ac00b99d5a5c845)
  - [`(vectors x, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-d271045bb5d0614ff3a2f0e3d8d279d134cf0304)
+ - [`(vectors x1, vectors x2, real alpha, real rho) : matrix`](removed_functions.qmd#index-entry-70b15de7e29e4e64f05ca3fc552da349d4a66c1f)
 
 
 **crossprod**:
@@ -689,13 +689,13 @@ pagetitle: Alphabetical Index
 
 **cumulative_sum**:
 
- - [`(complex_vector v) : complex_vector`](complex_matrix_operations.qmd#index-entry-45545f14726c28e6b63c8ec09e06e53b33e4ca02)
- - [`(complex_row_vector rv) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-c104f0e3e10596f559a8a023c84f92f1b919bc0f)
  - [`(array[] complex x) : array[] complex`](complex_matrix_operations.qmd#index-entry-d6b4157abb8f1f7140f20c5b9182ad2f7d69fe37)
  - [`(array[] int x) : array[] int`](matrix_operations.qmd#index-entry-092f8a13b9e06f8346cb61b8fc6a6fbacb3b5cc5)
  - [`(array[] real x) : array[] real`](matrix_operations.qmd#index-entry-1e965776faac7516107384178cafd382f87f909a)
- - [`(vector v) : vector`](matrix_operations.qmd#index-entry-7c00c2971c29f98a54f16c9468d5b4a6eb529ff8)
+ - [`(complex_row_vector rv) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-c104f0e3e10596f559a8a023c84f92f1b919bc0f)
+ - [`(complex_vector v) : complex_vector`](complex_matrix_operations.qmd#index-entry-45545f14726c28e6b63c8ec09e06e53b33e4ca02)
  - [`(row_vector rv) : row_vector`](matrix_operations.qmd#index-entry-951e3c465251f531a70f0dce6772057bf114685c)
+ - [`(vector v) : vector`](matrix_operations.qmd#index-entry-7c00c2971c29f98a54f16c9468d5b4a6eb529ff8)
 
 
 
@@ -725,16 +725,16 @@ pagetitle: Alphabetical Index
 
  - [`(complex_matrix m, complex_row_vector v) : complex_matrix`](complex_matrix_operations.qmd#index-entry-82629e9f9045325a28b4c0610df36226bc6c4562)
  - [`(complex_matrix m, complex_vector v) : complex_matrix`](complex_matrix_operations.qmd#index-entry-b8e527d5b7adcfe81f12d70984ba81d895332835)
- - [`(matrix m, vector v) : matrix`](matrix_operations.qmd#index-entry-2ff483d0f2d35ce6055a030912e1909c110453dc)
  - [`(matrix m, row_vector rv) : matrix`](matrix_operations.qmd#index-entry-fedf6c86ebf0663043f5e986e077701e6ae185f4)
+ - [`(matrix m, vector v) : matrix`](matrix_operations.qmd#index-entry-2ff483d0f2d35ce6055a030912e1909c110453dc)
 
 
 **diag_pre_multiply**:
 
  - [`(complex_row_vector v, complex_matrix m) : complex_matrix`](complex_matrix_operations.qmd#index-entry-29b61ea8d42d42252259e35dbe0c427c485ad9e8)
  - [`(complex_vector v, complex_matrix m) : complex_matrix`](complex_matrix_operations.qmd#index-entry-7907eb3baed066d578933e3832fe8366c02116eb)
- - [`(vector v, matrix m) : matrix`](matrix_operations.qmd#index-entry-0fc4d71e7bc087ce4f9dec77e1df8df248f41bac)
  - [`(row_vector rv, matrix m) : matrix`](matrix_operations.qmd#index-entry-87b1033ce509f3990ef4516c29c0b9b08d67c37b)
+ - [`(vector v, matrix m) : matrix`](matrix_operations.qmd#index-entry-0fc4d71e7bc087ce4f9dec77e1df8df248f41bac)
 
 
 **diagonal**:
@@ -830,30 +830,30 @@ pagetitle: Alphabetical Index
 
 **distance**:
 
- - [`(vector x, vector y) : real`](array_operations.qmd#index-entry-702855e7be40e4fcfbe31b5f08538c5fbfba210e)
- - [`(row_vector x, vector y) : real`](array_operations.qmd#index-entry-a9f701404655eb686e31e66d38918d7e08cd9f3b)
  - [`(row_vector x, row_vector y) : real`](array_operations.qmd#index-entry-c6112c85adc9432ce6b005aff57babec0dbee55e)
+ - [`(row_vector x, vector y) : real`](array_operations.qmd#index-entry-a9f701404655eb686e31e66d38918d7e08cd9f3b)
  - [`(vector x, row_vector y) : real`](array_operations.qmd#index-entry-d68901fc0a3ff9e987854900a185ee2713e5c520)
+ - [`(vector x, vector y) : real`](array_operations.qmd#index-entry-702855e7be40e4fcfbe31b5f08538c5fbfba210e)
 
 
 **dot_product**:
 
  - [`(complex_row_vector x, complex_row_vector y) : complex`](complex_matrix_operations.qmd#index-entry-13cdb97ea7e259e98791362de8a261d17dab4e1c)
- - [`(complex_vector x, complex_vector y) : complex`](complex_matrix_operations.qmd#index-entry-bc037b34a4fdc977a944e39e9277f8e6c700bd5b)
  - [`(complex_row_vector x, complex_vector y) : complex`](complex_matrix_operations.qmd#index-entry-d932a1eed6d525ce1077543b39b6834836923949)
  - [`(complex_vector x, complex_row_vector y) : complex`](complex_matrix_operations.qmd#index-entry-dd62ebed52c5e3210bb8a0155e1d5dfa70497439)
- - [`(vector x, row_vector y) : real`](matrix_operations.qmd#index-entry-4ce3d3846b8c242984aca259fd01579e1b2179af)
- - [`(row_vector x, vector y) : real`](matrix_operations.qmd#index-entry-5624c84e1a33f2cf540a3d8a2994205918d9915c)
+ - [`(complex_vector x, complex_vector y) : complex`](complex_matrix_operations.qmd#index-entry-bc037b34a4fdc977a944e39e9277f8e6c700bd5b)
  - [`(row_vector x, row_vector y) : real`](matrix_operations.qmd#index-entry-5fa1a043fd0dcebec0cb14fd09c1a965c33d37fe)
+ - [`(row_vector x, vector y) : real`](matrix_operations.qmd#index-entry-5624c84e1a33f2cf540a3d8a2994205918d9915c)
+ - [`(vector x, row_vector y) : real`](matrix_operations.qmd#index-entry-4ce3d3846b8c242984aca259fd01579e1b2179af)
  - [`(vector x, vector y) : real`](matrix_operations.qmd#index-entry-6f3cb76e0af87d28bceef319e85e75976645662e)
 
 
 **dot_self**:
 
- - [`(complex_vector x) : complex`](complex_matrix_operations.qmd#index-entry-1ae5feb968f94e219b01c1a6943eb1532161e16f)
  - [`(complex_row_vector x) : complex`](complex_matrix_operations.qmd#index-entry-d0945f42b843344d7b22f5d088d229c5f5ba64bf)
- - [`(vector x) : real`](matrix_operations.qmd#index-entry-1ae4fbadff5f8d76241c1cfc33e2c36db7decc73)
+ - [`(complex_vector x) : complex`](complex_matrix_operations.qmd#index-entry-1ae5feb968f94e219b01c1a6943eb1532161e16f)
  - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-806eb76bdef36d3ee3a9a009027593ad32d755f1)
+ - [`(vector x) : real`](matrix_operations.qmd#index-entry-1ae4fbadff5f8d76241c1cfc33e2c36db7decc73)
 
 
 **double_exponential**:
@@ -1083,8 +1083,8 @@ pagetitle: Alphabetical Index
 
 **fmod**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-206cb5e9da51b6d1255b47d019273ab50a84687c)
  - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-fed64eefc7fd2673daac1482490fb6dfc5e37647)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-206cb5e9da51b6d1255b47d019273ab50a84687c)
 
 
 **frechet**:
@@ -1156,14 +1156,14 @@ pagetitle: Alphabetical Index
 
 **gamma_p**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-07d2b4d046ed3e94ab2394782dbfb848ce338126)
  - [`(real a, real z) : real`](real-valued_basic_functions.qmd#index-entry-6a3cb9f6d55852cff80a67883177778548b712d0)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-07d2b4d046ed3e94ab2394782dbfb848ce338126)
 
 
 **gamma_q**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-4949830b870b509235b2289a32a4e00f6e52e309)
  - [`(real a, real z) : real`](real-valued_basic_functions.qmd#index-entry-5cd1f2570dd2f81dc1a8e6f344ba953142a29865)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-4949830b870b509235b2289a32a4e00f6e52e309)
 
 
 **gamma_rng**:
@@ -1184,8 +1184,8 @@ pagetitle: Alphabetical Index
 
 **gaussian_dlm_obs_lupdf**:
 
- - [`(matrix y | matrix F, matrix G, vector V, matrix W, vector m0, matrix C0) : real`](distributions_over_unbounded_vectors.qmd#index-entry-14842eb0078230e2e500d5478fb688e1fd8c7fd3)
  - [`(matrix y | matrix F, matrix G, matrix V, matrix W, vector m0, matrix C0) : real`](distributions_over_unbounded_vectors.qmd#index-entry-c55d98e7e02d60b3177dcb12f3f8a4d71d7b7770)
+ - [`(matrix y | matrix F, matrix G, vector V, matrix W, vector m0, matrix C0) : real`](distributions_over_unbounded_vectors.qmd#index-entry-14842eb0078230e2e500d5478fb688e1fd8c7fd3)
 
 
 **generalized_inverse**:
@@ -1244,10 +1244,10 @@ pagetitle: Alphabetical Index
 ## H
 **head**:
 
- - [`(complex_vector v, int n) : complex_vector`](complex_matrix_operations.qmd#index-entry-98d4004db4f7912b486209fbaa83ee186a0b4a0f)
- - [`(complex_row_vector rv, int n) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-9b30a21ff61d6bb263aeae6fe0f8eeaad19b6091)
- - [`(row_vector rv, int n) : row_vector`](matrix_operations.qmd#index-entry-3107ded9497fc42a02b0573d3453f8cfb6302a41)
  - [`(array[] T sv, int n) : array[] T`](matrix_operations.qmd#index-entry-57085692c2de5cb3a0be6af59e4d4db1087270b9)
+ - [`(complex_row_vector rv, int n) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-9b30a21ff61d6bb263aeae6fe0f8eeaad19b6091)
+ - [`(complex_vector v, int n) : complex_vector`](complex_matrix_operations.qmd#index-entry-98d4004db4f7912b486209fbaa83ee186a0b4a0f)
+ - [`(row_vector rv, int n) : row_vector`](matrix_operations.qmd#index-entry-3107ded9497fc42a02b0573d3453f8cfb6302a41)
  - [`(vector v, int n) : vector`](matrix_operations.qmd#index-entry-8422dde5d63a6c756136d01ceeae0de6de1b00cb)
 
 
@@ -1312,8 +1312,8 @@ pagetitle: Alphabetical Index
 
 **integrate_1d**:
 
- - [`(function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i), real relative_tolerance) : real`](higher-order_functions.qmd#index-entry-029333bb86d68fe853789eea2568f760cec8eff3)
  - [`(function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i) : real`](higher-order_functions.qmd#index-entry-39f0cbb60146855f8f98ba56502efcbfd04df2aa)
+ - [`(function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i), real relative_tolerance) : real`](higher-order_functions.qmd#index-entry-029333bb86d68fe853789eea2568f760cec8eff3)
 
 
 **integrate_ode**:
@@ -1335,8 +1335,8 @@ pagetitle: Alphabetical Index
 
 **integrate_ode_rk45**:
 
- - [`(function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i, real rel_tol, real abs_tol, int max_num_steps) : array[,] real`](deprecated_functions.qmd#index-entry-ed3282ca9353c591d894371c5da7f6c427ec52ff)
  - [`(function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i) : array[,] real`](deprecated_functions.qmd#index-entry-fddefd52462ff3a8c14cca8da72bb5ef1596fbe0)
+ - [`(function ode, array[] real initial_state, real initial_time, array[] real times, array[] real theta, array[] real x_r, array[] int x_i, real rel_tol, real abs_tol, int max_num_steps) : array[,] real`](deprecated_functions.qmd#index-entry-ed3282ca9353c591d894371c5da7f6c427ec52ff)
 
 
 **inv**:
@@ -1534,14 +1534,14 @@ pagetitle: Alphabetical Index
 
 **lchoose**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-57668b872958a1c748381739b2639e2c592b1635)
  - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-8db53df4cf96e86f2466a1a67a046f1e92e24a41)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-57668b872958a1c748381739b2639e2c592b1635)
 
 
 **ldexp**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-04b6e7e9f36a90c1074fe831b302e5a839cded46)
  - [`(real x, int y) : real`](real-valued_basic_functions.qmd#index-entry-87e15a5115cbb3320b6c75601022db5ce42d567f)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-04b6e7e9f36a90c1074fe831b302e5a839cded46)
 
 
 **lgamma**:
@@ -1617,8 +1617,8 @@ pagetitle: Alphabetical Index
 
 **lmultiply**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-5789074da7a4d0fb0e2acfe2db85408ed582f1a5)
  - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-d6659cf1923baf938d87ae82cf8fecf0665eb99d)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-5789074da7a4d0fb0e2acfe2db85408ed582f1a5)
 
 
 **log**:
@@ -1629,8 +1629,8 @@ pagetitle: Alphabetical Index
 
 **log10**:
 
- - [`(complex z) : complex`](complex-valued_basic_functions.qmd#index-entry-4d3907a677d8f4d4f89b1edc324ffe5fa2bfbafe)
  - [`() : real`](real-valued_basic_functions.qmd#index-entry-58b920bd8ecd5758726663c1663723631b6e1040)
+ - [`(complex z) : complex`](complex-valued_basic_functions.qmd#index-entry-4d3907a677d8f4d4f89b1edc324ffe5fa2bfbafe)
  - [`(T x) : R`](real-valued_basic_functions.qmd#index-entry-ad4651b8f653b4d8e1e6e50131371c8be7a35444)
 
 
@@ -1661,8 +1661,8 @@ pagetitle: Alphabetical Index
 
 **log2**:
 
- - [`(T x) : R`](real-valued_basic_functions.qmd#index-entry-8aa277afaded318050922a7e576d5531918c4fa3)
  - [`() : real`](real-valued_basic_functions.qmd#index-entry-8e60dd0524fa17b2bb9c1df45ec2cb91f313d8f6)
+ - [`(T x) : R`](real-valued_basic_functions.qmd#index-entry-8aa277afaded318050922a7e576d5531918c4fa3)
 
 
 **log_determinant**:
@@ -1672,8 +1672,8 @@ pagetitle: Alphabetical Index
 
 **log_diff_exp**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-a68b0818c49fbd4972dfb2a14fea67387662718e)
  - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-db5adfe0722d967066a4801ba7088570feda3d4f)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-a68b0818c49fbd4972dfb2a14fea67387662718e)
 
 
 **log_falling_factorial**:
@@ -1693,8 +1693,8 @@ pagetitle: Alphabetical Index
 
 **log_mix**:
 
- - [`(T1 theta, T2 lp1, T3 lp2) : R`](real-valued_basic_functions.qmd#index-entry-2a36a682590acfceeb277b003f5f529fa3ccd882)
  - [`(real theta, real lp1, real lp2) : real`](real-valued_basic_functions.qmd#index-entry-569bcea73548d03bb5791681fcc60ee056c259b3)
+ - [`(T1 theta, T2 lp1, T3 lp2) : R`](real-valued_basic_functions.qmd#index-entry-2a36a682590acfceeb277b003f5f529fa3ccd882)
 
 
 **log_modified_bessel_first_kind**:
@@ -1705,8 +1705,8 @@ pagetitle: Alphabetical Index
 
 **log_rising_factorial**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-67ec81c237fb98951165722160d48a4e93bbf167)
  - [`(real x, real n) : real`](real-valued_basic_functions.qmd#index-entry-72c705188e9fa2abc1fb72e724383889c9c3bc26)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-67ec81c237fb98951165722160d48a4e93bbf167)
 
 
 **log_softmax**:
@@ -1717,10 +1717,10 @@ pagetitle: Alphabetical Index
 **log_sum_exp**:
 
  - [`(array[] real x) : real`](array_operations.qmd#index-entry-7b26d9d0a4894d9b4686f4847de2d728f050eeca)
- - [`(vector x) : real`](matrix_operations.qmd#index-entry-12d207b1c215fc3ea15553df653cae3cbb14fbdf)
- - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-41527e620b092f6ca6efaca55f839d7ff1404f5b)
  - [`(matrix x) : real`](matrix_operations.qmd#index-entry-54afbd4baa0c2ccf7b5392bdff0c6c87fce8222c)
+ - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-41527e620b092f6ca6efaca55f839d7ff1404f5b)
  - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-da09d53c7797409929bfa868dfa8b30d767c1d2b)
+ - [`(vector x) : real`](matrix_operations.qmd#index-entry-12d207b1c215fc3ea15553df653cae3cbb14fbdf)
 
 
 **logistic**:
@@ -1847,24 +1847,24 @@ pagetitle: Alphabetical Index
 
 **max**:
 
- - [`(array[] real x) : real`](array_operations.qmd#index-entry-1dc0a9e5bd6f78b5d2904cba8c6375fa264e6990)
  - [`(array[] int x) : int`](array_operations.qmd#index-entry-b77840f6a6da285fe070a2db533be9470af54dfc)
+ - [`(array[] real x) : real`](array_operations.qmd#index-entry-1dc0a9e5bd6f78b5d2904cba8c6375fa264e6990)
  - [`(int x, int y) : int`](integer-valued_basic_functions.qmd#index-entry-fbc1a906ce513495836edb5c1cd222c564bcc768)
- - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-260d6b034f7c7e6500278a93262c8d5af5ebe636)
  - [`(matrix x) : real`](matrix_operations.qmd#index-entry-3f0b6dd3ba52477b4fef8985ad1e0a330b31afaf)
+ - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-260d6b034f7c7e6500278a93262c8d5af5ebe636)
  - [`(vector x) : real`](matrix_operations.qmd#index-entry-f2cd3ae46c31e2abdd35a92b4d10506f3c51f553)
 
 
 **mdivide_left_spd**:
 
- - [`(matrix A, vector b) : matrix`](matrix_operations.qmd#index-entry-0faeb825bd118874deb217de05883995b606c1e7)
  - [`(matrix A, matrix B) : vector`](matrix_operations.qmd#index-entry-cf5f3991e5dd2accb21ce017e9f96521b0735e68)
+ - [`(matrix A, vector b) : matrix`](matrix_operations.qmd#index-entry-0faeb825bd118874deb217de05883995b606c1e7)
 
 
 **mdivide_left_tri_low**:
 
- - [`(matrix A, vector b) : vector`](matrix_operations.qmd#index-entry-713d2983956ecba7e2e36a9e0614def9ea574bc6)
  - [`(matrix A, matrix B) : matrix`](matrix_operations.qmd#index-entry-871e5638d23fa382b4f449a8fa0a5fa1c9556ecd)
+ - [`(matrix A, vector b) : vector`](matrix_operations.qmd#index-entry-713d2983956ecba7e2e36a9e0614def9ea574bc6)
 
 
 **mdivide_right_spd**:
@@ -1882,9 +1882,9 @@ pagetitle: Alphabetical Index
 **mean**:
 
  - [`(array[] real x) : real`](array_operations.qmd#index-entry-bb1b7fccc6b17cde8f9e75a947464b97bc4082d3)
+ - [`(matrix x) : real`](matrix_operations.qmd#index-entry-fedafc3d15883df02af3a5cc3c738594e4aac9e9)
  - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-793945619c88050a3af516f403737ac131fdc6a3)
  - [`(vector x) : real`](matrix_operations.qmd#index-entry-895445a6a0170ef1bb8d7d7d9ed5eacdb328b24e)
- - [`(matrix x) : real`](matrix_operations.qmd#index-entry-fedafc3d15883df02af3a5cc3c738594e4aac9e9)
 
 
 **min**:
@@ -1892,9 +1892,9 @@ pagetitle: Alphabetical Index
  - [`(array[] int x) : int`](array_operations.qmd#index-entry-6f45b7ae2a16ec959cb22d041d7b50c43dada819)
  - [`(array[] real x) : real`](array_operations.qmd#index-entry-c4f3e810f70c09849013a04b92b38f9e93067e2f)
  - [`(int x, int y) : int`](integer-valued_basic_functions.qmd#index-entry-82a2d72a544284ee41b99d4842427ee71f7025b9)
- - [`(vector x) : real`](matrix_operations.qmd#index-entry-1930adf5f047ff599b49aa2b5dd87c8fabe47d92)
- - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-9aecdccfa0bdd71b2c969de650b8e72bad49df26)
  - [`(matrix x) : real`](matrix_operations.qmd#index-entry-f8c78579caf9c583f2f55067b99104c0e7132124)
+ - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-9aecdccfa0bdd71b2c969de650b8e72bad49df26)
+ - [`(vector x) : real`](matrix_operations.qmd#index-entry-1930adf5f047ff599b49aa2b5dd87c8fabe47d92)
 
 
 **modified_bessel_first_kind**:
@@ -1905,8 +1905,8 @@ pagetitle: Alphabetical Index
 
 **modified_bessel_second_kind**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-6340b47f5e4a5642b6c080962ca50fde4d6ea5d9)
  - [`(int v, real z) : real`](real-valued_basic_functions.qmd#index-entry-e174dc75cd0e499de88270d4616de1ca6cb81235)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-6340b47f5e4a5642b6c080962ca50fde4d6ea5d9)
 
 
 **multi_gp**:
@@ -1951,42 +1951,42 @@ pagetitle: Alphabetical Index
 
 **multi_normal_cholesky_lpdf**:
 
- - [`(row_vectors y | vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-69e5b64a11f77c97cd0fffeaee869c5358969237)
- - [`(vectors y | vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-b197f45c690e4b7dd4ebe29d9f75790be4acf177)
  - [`(row_vectors y | row_vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-d5709f43c49fc57a5ef58e94e176962d2bff379a)
+ - [`(row_vectors y | vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-69e5b64a11f77c97cd0fffeaee869c5358969237)
  - [`(vectors y | row_vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-efdc316743c9c9f1a6ee782650494ee45cb045cd)
+ - [`(vectors y | vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-b197f45c690e4b7dd4ebe29d9f75790be4acf177)
 
 
 **multi_normal_cholesky_lupdf**:
 
  - [`(row_vectors y | row_vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-1606261a4f25b4e68b2bf4b1c8bf2513e62cdf5c)
- - [`(vectors y | vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-2ac54d7aebe6a22693ee5a9016fef469246a746c)
- - [`(vectors y | row_vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-a04f4fcdecc170b474051229edff4d2358b9c619)
  - [`(row_vectors y | vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-d3682df812ba6f35ad608d62b19f6c8ca23601f7)
+ - [`(vectors y | row_vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-a04f4fcdecc170b474051229edff4d2358b9c619)
+ - [`(vectors y | vectors mu, matrix L) : real`](distributions_over_unbounded_vectors.qmd#index-entry-2ac54d7aebe6a22693ee5a9016fef469246a746c)
 
 
 **multi_normal_cholesky_rng**:
 
- - [`(vectors mu, matrix L) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-7e60f3380a18c3f7bbcc383bfa7fcd15c14c054b)
  - [`(row_vector mu, matrix L) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-83a370eb75f07ac047e03e4dde9d64cf42e4c432)
- - [`(vector mu, matrix L) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-b2936af169906302b9686d4673d8c5a8da710efb)
  - [`(row_vectors mu, matrix L) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-e6934af3e7cb8c68c3aa044307129bbaf17ffabf)
+ - [`(vector mu, matrix L) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-b2936af169906302b9686d4673d8c5a8da710efb)
+ - [`(vectors mu, matrix L) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-7e60f3380a18c3f7bbcc383bfa7fcd15c14c054b)
 
 
 **multi_normal_lpdf**:
 
  - [`(row_vectors y | row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-7d157b823f0ae33310094712caff4096b644a282)
+ - [`(row_vectors y | vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-fe635d231edc36e95bda6936e3dc7f58cf04d7b9)
  - [`(vectors y | row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-c1e8d116401a5e7f66812da95e1285dc2a3b111a)
  - [`(vectors y | vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-ea7d4337cebac7fdbfa928b24a3626208823e80e)
- - [`(row_vectors y | vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-fe635d231edc36e95bda6936e3dc7f58cf04d7b9)
 
 
 **multi_normal_lupdf**:
 
- - [`(row_vectors y | vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-69f99f5b6cefce126adc27f7b20728705d7e8a53)
- - [`(vectors y | vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-7786848b839eeda0bfa728760464ac4a8369550d)
  - [`(row_vectors y | row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-86c5dd8e6cf2c484c3c76fffcadc99f786b7265b)
+ - [`(row_vectors y | vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-69f99f5b6cefce126adc27f7b20728705d7e8a53)
  - [`(vectors y | row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-a0fb7f94e06645589741da551fba4a55a0a33e44)
+ - [`(vectors y | vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-7786848b839eeda0bfa728760464ac4a8369550d)
 
 
 **multi_normal_prec**:
@@ -1996,26 +1996,26 @@ pagetitle: Alphabetical Index
 
 **multi_normal_prec_lpdf**:
 
- - [`(vectors y | vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-6a00a4a10d9e84eaa51e885395294f4b4e1272dd)
+ - [`(row_vectors y | row_vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-eb92ca14c43c32d999ac0b10e2160f641a23f265)
  - [`(row_vectors y | vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-8efc2d6f42f7fd5eeb961e3959b617201d45a58c)
  - [`(vectors y | row_vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-dcfb9bff5f659aa499401ffd77ffd7bbaa784936)
- - [`(row_vectors y | row_vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-eb92ca14c43c32d999ac0b10e2160f641a23f265)
+ - [`(vectors y | vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-6a00a4a10d9e84eaa51e885395294f4b4e1272dd)
 
 
 **multi_normal_prec_lupdf**:
 
- - [`(row_vectors y | vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-314ed87058998a1934a7cd80a00abca432768d68)
  - [`(row_vectors y | row_vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-9cf50bfea31a9655df9c07627982295a3a884afa)
- - [`(vectors y | vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-e4db099421dc8d5cb5ccaf22226497142e4ad656)
+ - [`(row_vectors y | vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-314ed87058998a1934a7cd80a00abca432768d68)
  - [`(vectors y | row_vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-ec0990b5c058b76b441e3132b8e4986f8fc3b9a6)
+ - [`(vectors y | vectors mu, matrix Omega) : real`](distributions_over_unbounded_vectors.qmd#index-entry-e4db099421dc8d5cb5ccaf22226497142e4ad656)
 
 
 **multi_normal_rng**:
 
- - [`(row_vectors mu, matrix Sigma) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-214830eeea24ebd3c375e92411ceab1101a15b6c)
  - [`(row_vector mu, matrix Sigma) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-70771ae7e3296e2a09378f81d64a16d0ffdebe49)
- - [`(vectors mu, matrix Sigma) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-ba20f2e8644cf2fff8761565c61ae10f1160df3a)
+ - [`(row_vectors mu, matrix Sigma) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-214830eeea24ebd3c375e92411ceab1101a15b6c)
  - [`(vector mu, matrix Sigma) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-d83a51f846b5823f2e419d6189b27cd98643a584)
+ - [`(vectors mu, matrix Sigma) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-ba20f2e8644cf2fff8761565c61ae10f1160df3a)
 
 
 **multi_student_cholesky_t_rng**:
@@ -2052,25 +2052,25 @@ pagetitle: Alphabetical Index
 **multi_student_t_lpdf**:
 
  - [`(row_vectors y | real nu, row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-5b6e5c7b1a5d8704f96553d2ccd4fb053bdb4917)
- - [`(vectors y | real nu, vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-69dbd18bfe0fa38bad7531c187ffd5ddbc68655e)
- - [`(vectors y | real nu, row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-97bab7be0967824f68beadb09ab9fc5152e4b605)
  - [`(row_vectors y | real nu, vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-b0e0974e59e75e19f6b6c4aa22d8395d7ef922de)
+ - [`(vectors y | real nu, row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-97bab7be0967824f68beadb09ab9fc5152e4b605)
+ - [`(vectors y | real nu, vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-69dbd18bfe0fa38bad7531c187ffd5ddbc68655e)
 
 
 **multi_student_t_lupdf**:
 
- - [`(vectors y | real nu, row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-74a88cd182b98cb2259da79ec60775f5d1f01084)
- - [`(row_vectors y | real nu, vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-7b3d937ea2e301a8d2455c2939ef7fc5c815d5ca)
  - [`(row_vectors y | real nu, row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-d92dadb3604f6521420ca422b762d25b60b94dbf)
+ - [`(row_vectors y | real nu, vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-7b3d937ea2e301a8d2455c2939ef7fc5c815d5ca)
+ - [`(vectors y | real nu, row_vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-74a88cd182b98cb2259da79ec60775f5d1f01084)
  - [`(vectors y | real nu, vectors mu, matrix Sigma) : real`](distributions_over_unbounded_vectors.qmd#index-entry-ed2f0cb9d8bc8294e4c924451d7f556f82d5157c)
 
 
 **multi_student_t_rng**:
 
  - [`(real nu, row_vector mu, matrix Sigma) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-18f756f159784f68dc00bac1706c5e31f805daf3)
- - [`(real nu, vectors mu, matrix Sigma) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-d65fa98b0f3f647ffd2cbe3f445ab17be93735dc)
- - [`(real nu, vector mu, matrix Sigma) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-e2a99afdcb2cc3ec5ffc0367d7d241f2b511a575)
  - [`(real nu, row_vectors mu, matrix Sigma) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-f05b8a3480e2360d1224acb270aca05c90674ba1)
+ - [`(real nu, vector mu, matrix Sigma) : vector`](distributions_over_unbounded_vectors.qmd#index-entry-e2a99afdcb2cc3ec5ffc0367d7d241f2b511a575)
+ - [`(real nu, vectors mu, matrix Sigma) : vectors`](distributions_over_unbounded_vectors.qmd#index-entry-d65fa98b0f3f647ffd2cbe3f445ab17be93735dc)
 
 
 **multinomial**:
@@ -2158,21 +2158,21 @@ pagetitle: Alphabetical Index
 **neg_binomial_2_log_glm_lpmf**:
 
  - [`(array[] int y | matrix x, real alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-145c118038ba258504502a0ca981d7c12532bc51)
+ - [`(array[] int y | matrix x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-f5314e218cc2c6e5fe4e6301645ec2c0fdafbc11)
  - [`(array[] int y | row_vector x, real alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-16a3cf3cfe06586324838df97a33fbb2c2efeef7)
  - [`(array[] int y | row_vector x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-30a171234617b31ebd3414cb4a4f82c1b62b3d34)
  - [`(int y | matrix x, real alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-7fe4a0797bb0b9fced5c0f2d75c06e1e479ea248)
  - [`(int y | matrix x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-91d1747bb7a9e5a3edc9ed5ec4c377f643eac2ca)
- - [`(array[] int y | matrix x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-f5314e218cc2c6e5fe4e6301645ec2c0fdafbc11)
 
 
 **neg_binomial_2_log_glm_lupmf**:
 
- - [`(int y | matrix x, real alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-09ef2622134a433c0f9c3ad0643e20255979e98a)
- - [`(array[] int y | matrix x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-7346fdbc1e0f782c1d3ab15e9f444e03bc33b644)
  - [`(array[] int y | matrix x, real alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-c5e5488af5e4e66825ea2b163862a7d35f6dd124)
+ - [`(array[] int y | matrix x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-7346fdbc1e0f782c1d3ab15e9f444e03bc33b644)
  - [`(array[] int y | row_vector x, real alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-c6a6b66b9c19ab430c255ed8047ad014e1f6414c)
- - [`(int y | matrix x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-d01dd7632fe36e888d0067b62cae9fd79230af8d)
  - [`(array[] int y | row_vector x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-e736537c82f56050b3aaf75e43b6d50a38477dd9)
+ - [`(int y | matrix x, real alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-09ef2622134a433c0f9c3ad0643e20255979e98a)
+ - [`(int y | matrix x, vector alpha, vector beta, real phi) : real`](unbounded_discrete_distributions.qmd#index-entry-d01dd7632fe36e888d0067b62cae9fd79230af8d)
 
 
 **neg_binomial_2_log_lpmf**:
@@ -2247,15 +2247,15 @@ pagetitle: Alphabetical Index
 
 **norm1**:
 
+ - [`(array[] real x) : real`](array_operations.qmd#index-entry-d29d5686fa464cc82765e365c73f1ebb70954ffa)
  - [`(row_vector x) : real`](array_operations.qmd#index-entry-3a384b9bbb192b688afb1c9e95a490200da65412)
  - [`(vector x) : real`](array_operations.qmd#index-entry-64a22469a1ca08b874dfd1f7dba4e60a02311a4d)
- - [`(array[] real x) : real`](array_operations.qmd#index-entry-d29d5686fa464cc82765e365c73f1ebb70954ffa)
 
 
 **norm2**:
 
- - [`(row_vector x) : real`](array_operations.qmd#index-entry-15be5905b3ac40ce77299341b9e7434d6e5a721e)
  - [`(array[] real x) : real`](array_operations.qmd#index-entry-95748dc7d816217c82a900a5cefd801980794a10)
+ - [`(row_vector x) : real`](array_operations.qmd#index-entry-15be5905b3ac40ce77299341b9e7434d6e5a721e)
  - [`(vector x) : real`](array_operations.qmd#index-entry-bd1aec552c96bca3230c994fb47fa42e54632e5e)
 
 
@@ -2276,30 +2276,30 @@ pagetitle: Alphabetical Index
 
 **normal_id_glm_lpdf**:
 
- - [`(vector y | matrix x, real alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-1428e7cc017ba5e7e160484c9051cfb458221d42)
- - [`(vector y | row_vector x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-1d3d0f48ac6b8ae87eab8640482747cc1d3bcc65)
  - [`(real y | matrix x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-4436deedaa4adcaf697328f4ab6228f12bf213be)
- - [`(real y | matrix x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-4fc2715c69e219915d6372ded62c513ec2dad353)
- - [`(vector y | matrix x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-5bce6923d1e27b6dfdb1112d0e26e6f2fccf3704)
- - [`(real y | matrix x, vector alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-7991a0ad137f72771bee6ae8bfe2a09dba063c5a)
  - [`(real y | matrix x, real alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-90d8f9b890b2588b36ed285cfb031e89bf170935)
- - [`(vector y | matrix x, vector alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-bc577f1feffdbfa17e7321f5cd733afccd7e822f)
+ - [`(real y | matrix x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-4fc2715c69e219915d6372ded62c513ec2dad353)
+ - [`(real y | matrix x, vector alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-7991a0ad137f72771bee6ae8bfe2a09dba063c5a)
+ - [`(vector y | matrix x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-5bce6923d1e27b6dfdb1112d0e26e6f2fccf3704)
+ - [`(vector y | matrix x, real alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-1428e7cc017ba5e7e160484c9051cfb458221d42)
  - [`(vector y | matrix x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-c8b35bcd76ae895df16171156e9ddc2b50977858)
+ - [`(vector y | matrix x, vector alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-bc577f1feffdbfa17e7321f5cd733afccd7e822f)
+ - [`(vector y | row_vector x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-1d3d0f48ac6b8ae87eab8640482747cc1d3bcc65)
  - [`(vector y | row_vector x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-d67cdb934c8fdbe441e7968e31d3d42bdc6bb46f)
 
 
 **normal_id_glm_lupdf**:
 
- - [`(vector y | row_vector x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-1aefc00a65f6adeb0cba0329b66f968d6caf1427)
+ - [`(real y | matrix x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-ef0f44ddfb9e65d97bec95df9bc84e88a5262ebc)
  - [`(real y | matrix x, real alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-2604f4a479cd2758a8273ebc888a4f35d707bcc3)
- - [`(vector y | row_vector x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-29d66019b47c2be1df4e8cb54f85a3459f41d7be)
- - [`(vector y | matrix x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-348b5a5c6bc0a9340114bd7744603300d84580bb)
- - [`(vector y | matrix x, vector alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-6c41e1877f2f156d78215c8b4f25b5795223a0d3)
- - [`(vector y | matrix x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-b410b1737bb33ec4400eae94d05bb37faea0c0e9)
  - [`(real y | matrix x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-baaf096f4f58b53d3142ade26076839f36733a39)
  - [`(real y | matrix x, vector alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-d7b73dfd16de89ad209b2a04905cdae1169f761c)
+ - [`(vector y | matrix x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-b410b1737bb33ec4400eae94d05bb37faea0c0e9)
  - [`(vector y | matrix x, real alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-e4b62bbce38476467b6d5d8347d048688b1b22fe)
- - [`(real y | matrix x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-ef0f44ddfb9e65d97bec95df9bc84e88a5262ebc)
+ - [`(vector y | matrix x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-348b5a5c6bc0a9340114bd7744603300d84580bb)
+ - [`(vector y | matrix x, vector alpha, vector beta, vector sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-6c41e1877f2f156d78215c8b4f25b5795223a0d3)
+ - [`(vector y | row_vector x, real alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-1aefc00a65f6adeb0cba0329b66f968d6caf1427)
+ - [`(vector y | row_vector x, vector alpha, vector beta, real sigma) : real`](unbounded_continuous_distributions.qmd#index-entry-29d66019b47c2be1df4e8cb54f85a3459f41d7be)
 
 
 **normal_lccdf**:
@@ -2335,11 +2335,11 @@ pagetitle: Alphabetical Index
 **num_elements**:
 
  - [`(array[] T x) : int`](array_operations.qmd#index-entry-a7f3950f11e27f31d9607b74a4cc9d5201f6f5ba)
+ - [`(complex_matrix x) : int`](complex_matrix_operations.qmd#index-entry-ea9bb96c32abb986ac353999ee38effe98c2999e)
  - [`(complex_row_vector x) : int`](complex_matrix_operations.qmd#index-entry-18b5a5e8da0b97e5db61bc2558be5861bb0e60c9)
  - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-5f67a5c5dc6caa692838121eb1be3a0294ad191f)
- - [`(complex_matrix x) : int`](complex_matrix_operations.qmd#index-entry-ea9bb96c32abb986ac353999ee38effe98c2999e)
- - [`(row_vector x) : int`](matrix_operations.qmd#index-entry-25d1da3aed0f07d9c6a36b34c0d238d180ebc272)
  - [`(matrix x) : int`](matrix_operations.qmd#index-entry-77dd48e13c18141a06bb49ceb67e01b76c4e3fae)
+ - [`(row_vector x) : int`](matrix_operations.qmd#index-entry-25d1da3aed0f07d9c6a36b34c0d238d180ebc272)
  - [`(vector x) : int`](matrix_operations.qmd#index-entry-9173ff057d7657581e5abf426a39637cb2339c11)
 
 
@@ -2462,40 +2462,40 @@ pagetitle: Alphabetical Index
 **operator'**:
 
  - [`(complex_matrix x) : complex_matrix`](complex_matrix_operations.qmd#index-entry-091a4926b279f9df738ff9dcd356e2436c3f9485)
- - [`(complex_vector x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-7b294083ea64b206b4b02446640de44855355156)
  - [`(complex_row_vector x) : complex_vector`](complex_matrix_operations.qmd#index-entry-ef45f4afc752618674b3095733d0dad1150a39fd)
- - [`(vector x) : row_vector`](matrix_operations.qmd#index-entry-5b05ea20fccc5c44353c7f5813ec3ce694b07cb6)
+ - [`(complex_vector x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-7b294083ea64b206b4b02446640de44855355156)
  - [`(matrix x) : matrix`](matrix_operations.qmd#index-entry-794bf86d8a081a75147a013481f07740310bb0d8)
  - [`(row_vector x) : vector`](matrix_operations.qmd#index-entry-e3432686a771bad98175ab4a594d8156ab915492)
+ - [`(vector x) : row_vector`](matrix_operations.qmd#index-entry-5b05ea20fccc5c44353c7f5813ec3ce694b07cb6)
 
 
 **operator\***:
 
  - [`(complex x, complex y) : complex`](complex-valued_basic_functions.qmd#index-entry-e3a6425a4fd372a6a28b66eb58c06245046f87ae)
+ - [`(complex x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a69bac506948c37d27beb39e793ff1339a67bf85)
+ - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-96bd6d9926f3cf86d4abdf08767a6078cd45be14)
+ - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-a79cd86a9e357f4daa3c2a357da7fe74a1591449)
+ - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-ec01c1a12f2dee572064680e87666ff43581e98e)
+ - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-e6c145519223a7e32befa818a711dd8470e7264d)
+ - [`(complex_matrix x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-7e59bb7495322cfae3a60e7cd858c8ea8ad00be4)
+ - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-989f9db43310c8b2278983062fe9699e275f0f4b)
+ - [`(complex_row_vector x, complex_matrix y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-eb9d524d09ed2def387f6d32e50434f1d04bb45a)
+ - [`(complex_row_vector x, complex_vector y) : complex`](complex_matrix_operations.qmd#index-entry-6a24a75ba519ef262ca78b4f7e1077124ff4e67b)
  - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-23a93f16e6035cc32b84ecf97c32845e9008702c)
  - [`(complex_vector x, complex_row_vector y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-6036495abafc183b219e271873881cec3f6e46a3)
- - [`(complex_row_vector x, complex_vector y) : complex`](complex_matrix_operations.qmd#index-entry-6a24a75ba519ef262ca78b4f7e1077124ff4e67b)
- - [`(complex_matrix x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-7e59bb7495322cfae3a60e7cd858c8ea8ad00be4)
- - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-96bd6d9926f3cf86d4abdf08767a6078cd45be14)
- - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-989f9db43310c8b2278983062fe9699e275f0f4b)
- - [`(complex x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a69bac506948c37d27beb39e793ff1339a67bf85)
- - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-a79cd86a9e357f4daa3c2a357da7fe74a1591449)
- - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-e6c145519223a7e32befa818a711dd8470e7264d)
- - [`(complex_row_vector x, complex_matrix y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-eb9d524d09ed2def387f6d32e50434f1d04bb45a)
- - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-ec01c1a12f2dee572064680e87666ff43581e98e)
  - [`(int x, int y) : int`](integer-valued_basic_functions.qmd#index-entry-74f2ac23b7142dcb99d72c2d668ea84d112f43ef)
+ - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-a87089afcc4f8cc865a9447f93284dd4a7903eaf)
+ - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-7c526c1ddbd012a188345676d03d7d8e52a2f4af)
+ - [`(matrix x, vector y) : vector`](matrix_operations.qmd#index-entry-c61d79dac022af07a0f553fb494511099410cdac)
+ - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-662e0b2447d3b372fc219293e38410d49bad1b7b)
+ - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-08f55cee893fdef254457be66b7a82c1d942ad0e)
+ - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-84a0cd07fdb794ec75d40dfa3c1638586ce59f1a)
+ - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-af34e073da12073d94a55fde49701a8f65786b67)
  - [`(row_vector x, matrix y) : row_vector`](matrix_operations.qmd#index-entry-0d741e9840edb32e9575051107190f0632ec5dd3)
+ - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-852b4c73c95c85062105d4a058743e342d831c9a)
+ - [`(row_vector x, vector y) : real`](matrix_operations.qmd#index-entry-c64d64dd72ff726168c121c89601f1e1fa602276)
  - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-29c74f1694c2364957ad8d79e09cfb3ad47e775b)
  - [`(vector x, row_vector y) : matrix`](matrix_operations.qmd#index-entry-3669aca452e27a8b48f0358b3d3103bc4d0d9530)
- - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-662e0b2447d3b372fc219293e38410d49bad1b7b)
- - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-7c526c1ddbd012a188345676d03d7d8e52a2f4af)
- - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-84a0cd07fdb794ec75d40dfa3c1638586ce59f1a)
- - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-852b4c73c95c85062105d4a058743e342d831c9a)
- - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-a87089afcc4f8cc865a9447f93284dd4a7903eaf)
- - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-af34e073da12073d94a55fde49701a8f65786b67)
- - [`(matrix x, vector y) : vector`](matrix_operations.qmd#index-entry-c61d79dac022af07a0f553fb494511099410cdac)
- - [`(row_vector x, vector y) : real`](matrix_operations.qmd#index-entry-c64d64dd72ff726168c121c89601f1e1fa602276)
- - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-08f55cee893fdef254457be66b7a82c1d942ad0e)
 
 
 **operator\*=**:
@@ -2506,30 +2506,30 @@ pagetitle: Alphabetical Index
 
 **operator+**:
 
- - [`(complex z) : complex`](complex-valued_basic_functions.qmd#index-entry-5fcb0e5cdd3aa28c383cc6808af8d0523f581e11)
  - [`(complex x, complex y) : complex`](complex-valued_basic_functions.qmd#index-entry-b67896f1b7c21199de738af1835d35fe36635012)
+ - [`(complex x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-3cbf469cad59cf318ccf139f90a016fc4bfe3db1)
+ - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-cf423b623dd5296c4bed0996e11793cfff99b12b)
+ - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-5a80c22fc9ab785c199e3ea9ba3903429f3308f9)
+ - [`(complex z) : complex`](complex-valued_basic_functions.qmd#index-entry-5fcb0e5cdd3aa28c383cc6808af8d0523f581e11)
  - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-0b1ee3eff7624a28d75d9cbdf065d8cb936c401a)
  - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-1c6e89ffde910406a3f594d11872988647733d8f)
- - [`(complex x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-3cbf469cad59cf318ccf139f90a016fc4bfe3db1)
- - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-5a80c22fc9ab785c199e3ea9ba3903429f3308f9)
  - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-83570c79a3f99ef98736dec5190a738977bf1986)
- - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-c4da2f5e129a64de4d83c12e2a8d2d79d7cd1619)
- - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-cf423b623dd5296c4bed0996e11793cfff99b12b)
- - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-e2a4a5c6172fcff3b822f22f17e4012616aa798b)
  - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-e4a7e3cd9cefa9964eb063b241f963f7b27007e7)
+ - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-e2a4a5c6172fcff3b822f22f17e4012616aa798b)
+ - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-c4da2f5e129a64de4d83c12e2a8d2d79d7cd1619)
  - [`(int x) : int`](integer-valued_basic_functions.qmd#index-entry-1b4db535db6b20e4b8af55f41af6ee4d6b5df6bd)
  - [`(int x, int y) : int`](integer-valued_basic_functions.qmd#index-entry-2e81f507ecb4144548330dac4d8bbc43686cd3e2)
- - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-0465a61949555ef4ef44514ccba8174500deeefa)
- - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-1a0c872aa1e302e3fd5a2a167b97e3ca6719d10c)
- - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-26044cd5506e5c4fc2579fc6466dd3f81d6408ce)
- - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-33e5719f2f10f7ff91219c35213757ec24c6b306)
  - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-718549a6ddfc2c775f69b8bc7a28fc7c053a7fbe)
  - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-77931799ac0a444f9530777cce44cb987abf32cb)
- - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-925b4d95d12aaad5ae3a3d5a5b8d06d9f36c3b9b)
- - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-f9354975ff6bc2974a4d1661855cea524ca49b50)
- - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-fd064b77a97b1ec9168687d5a25cde11da015591)
- - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-4b2af0abc1a2c8338794b49b801ff4d63be2f574)
  - [`(real x) : real`](real-valued_basic_functions.qmd#index-entry-54245a5adfc60f65ced33cbdf4571aeb7536afc3)
+ - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-0465a61949555ef4ef44514ccba8174500deeefa)
+ - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-4b2af0abc1a2c8338794b49b801ff4d63be2f574)
+ - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-fd064b77a97b1ec9168687d5a25cde11da015591)
+ - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-f9354975ff6bc2974a4d1661855cea524ca49b50)
+ - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-26044cd5506e5c4fc2579fc6466dd3f81d6408ce)
+ - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-33e5719f2f10f7ff91219c35213757ec24c6b306)
+ - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-925b4d95d12aaad5ae3a3d5a5b8d06d9f36c3b9b)
+ - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-1a0c872aa1e302e3fd5a2a167b97e3ca6719d10c)
 
 
 **operator+=**:
@@ -2540,41 +2540,41 @@ pagetitle: Alphabetical Index
 
 **operator-**:
 
- - [`(T x) : T`](complex-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
- - [`(complex z) : complex`](complex-valued_basic_functions.qmd#index-entry-34804cfa841db4ee3b8175eb5bbb0a124b639049)
  - [`(complex x, complex y) : complex`](complex-valued_basic_functions.qmd#index-entry-7aaca5ac69e98f6d2bc4db949541e8c69d18e694)
- - [`(T x) : T`](complex_matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
- - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-149f85a65fcb71890f2740b37f3d8e99d171c293)
- - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-19c0fa6f4a31be826fff56b079a14d03456e94c6)
- - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-23a25b349111e68acc8ccbf019f247a0857b9f9a)
- - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-2b25bbe909c531da7ca053dec04d2a0d66767407)
- - [`(complex_row_vector x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-4849f1558fb4d3addc5296dec7dc076fc33e2ac8)
- - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-4b7f3f2a15c41213894ee287a6fd4532d8ca59fb)
- - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-750993752e1971b5caa4b40e151244295537237d)
  - [`(complex x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a49311f2dd1b5d25aa68b099771fc781e15783c3)
  - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-be634502437e0887fcb531772138f252af5cd41b)
- - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-c159327226df72cad0b808e6e72271542904ae9b)
+ - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-149f85a65fcb71890f2740b37f3d8e99d171c293)
+ - [`(complex z) : complex`](complex-valued_basic_functions.qmd#index-entry-34804cfa841db4ee3b8175eb5bbb0a124b639049)
  - [`(complex_matrix x) : complex_matrix`](complex_matrix_operations.qmd#index-entry-c67e9b27b61ec87f6671f881e99e0215abca731a)
+ - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-19c0fa6f4a31be826fff56b079a14d03456e94c6)
+ - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-4b7f3f2a15c41213894ee287a6fd4532d8ca59fb)
+ - [`(complex_row_vector x) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-4849f1558fb4d3addc5296dec7dc076fc33e2ac8)
+ - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-23a25b349111e68acc8ccbf019f247a0857b9f9a)
+ - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-c159327226df72cad0b808e6e72271542904ae9b)
  - [`(complex_vector x) : complex_vector`](complex_matrix_operations.qmd#index-entry-e5e977ad448b9356d9822a744773c212eb665b80)
- - [`(T x) : T`](integer-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
- - [`(int x, int y) : int`](integer-valued_basic_functions.qmd#index-entry-63c9680853b8c13d6503afb15b5628911298a42a)
+ - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-750993752e1971b5caa4b40e151244295537237d)
+ - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-2b25bbe909c531da7ca053dec04d2a0d66767407)
  - [`(int x) : int`](integer-valued_basic_functions.qmd#index-entry-ef76e937371aef8a99cfd4a9964fd54af23d7344)
- - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-0dea3575356afb28b43da9a9985361d5ba7e1c84)
- - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-0e7a932586415d9249383de3efe664eb105f4a4f)
- - [`(T x) : T`](matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
- - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-6002a07176762b3c481c6761e8e06b1294e8d625)
+ - [`(int x, int y) : int`](integer-valued_basic_functions.qmd#index-entry-63c9680853b8c13d6503afb15b5628911298a42a)
  - [`(matrix x) : matrix`](matrix_operations.qmd#index-entry-6ca73a0303dd24f82990cf099176d76ea4f50d3b)
+ - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-b9ba1d02d3a73b7e8733514fb6b3a1c59414ee37)
+ - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-88db741d085202e8824acf87fdf5652fbc176914)
+ - [`(real x) : real`](real-valued_basic_functions.qmd#index-entry-2055033f59d0333f7b514dd496153b272c1b274c)
+ - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-aa6b0f0e0b80d8bcc4d95c623445e021142a9439)
+ - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-739fd04c545b6d65855bc20e05617df813db0598)
+ - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-6002a07176762b3c481c6761e8e06b1294e8d625)
  - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-76b3ba43bb249ac182c9f4fea095ea81ede76ebd)
  - [`(row_vector x) : row_vector`](matrix_operations.qmd#index-entry-7fa245ebd36b8195ee47b5cf42158c3936625d93)
- - [`(vector x) : vector`](matrix_operations.qmd#index-entry-8339baafb56b84ffc02ddc234752ab1f7a46e1e3)
- - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-88db741d085202e8824acf87fdf5652fbc176914)
- - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-8b1168c1cebe948416436c1c61cb7d7210949fae)
- - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-aa6b0f0e0b80d8bcc4d95c623445e021142a9439)
- - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-b9ba1d02d3a73b7e8733514fb6b3a1c59414ee37)
+ - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-0e7a932586415d9249383de3efe664eb105f4a4f)
  - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-f9f5c0ef9c18e80c24aa789a90b7d1253096fa3a)
+ - [`(T x) : T`](matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
+ - [`(T x) : T`](complex_matrix_operations.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
+ - [`(T x) : T`](complex-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
+ - [`(T x) : T`](integer-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
  - [`(T x) : T`](real-valued_basic_functions.qmd#index-entry-12e466dce5df3d58d3ad7f47d7637bc66c0c3b0f)
- - [`(real x) : real`](real-valued_basic_functions.qmd#index-entry-2055033f59d0333f7b514dd496153b272c1b274c)
- - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-739fd04c545b6d65855bc20e05617df813db0598)
+ - [`(vector x) : vector`](matrix_operations.qmd#index-entry-8339baafb56b84ffc02ddc234752ab1f7a46e1e3)
+ - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-0dea3575356afb28b43da9a9985361d5ba7e1c84)
+ - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-8b1168c1cebe948416436c1c61cb7d7210949fae)
 
 
 **operator-=**:
@@ -2585,11 +2585,11 @@ pagetitle: Alphabetical Index
 
 **operator.\***:
 
- - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-8225aa3a59b24f94b5efa4533b49050ef65e64ca)
  - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-8eb7c34b5da648cda9b6f992d4218d023c05d1da)
+ - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-8225aa3a59b24f94b5efa4533b49050ef65e64ca)
  - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-955eb57e60395b2be45f5af21989a3aff5f5db70)
- - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-296aa89afe5256f9cb944c3ce9458197bd833313)
  - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-6dec717a6b41050c89af60556ec7baae6bb8bb75)
+ - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-296aa89afe5256f9cb944c3ce9458197bd833313)
  - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-f6b9c926ae8c20a429454fbfd788a05c447ca21f)
 
 
@@ -2600,24 +2600,24 @@ pagetitle: Alphabetical Index
 
 **operator./**:
 
- - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-0f3d53dc1ff728a9ee7518e0ad5992c1fedcb7ff)
- - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-17e7fc9ed1291f3c3a332e54b65762dcac73f699)
- - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-5380455bf8d01c0d94b7994157ecd464dff285ab)
  - [`(complex x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-55e666acb9e555e6085cb69b1bf90e25b210d14b)
+ - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-5380455bf8d01c0d94b7994157ecd464dff285ab)
  - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-97bb359024d4f5bab6603c1d02519ed1e7641737)
- - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a68b100764978dc37adb03c4ac341b3369fa83af)
- - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-d6ea602ecffe4e62bb465b28956200dec419c158)
  - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-f5684bfa80a80f64afb4be43b829a06f2d3201fa)
+ - [`(complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-a68b100764978dc37adb03c4ac341b3369fa83af)
  - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-f83946686d65ec544820b3c6401ce2e3000cc1a9)
- - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-1800a4c4e6451dd14c0759f41c3b260e10010627)
- - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-33b751b1c6fcaa79a1f249d90774c58df3a3146f)
+ - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-d6ea602ecffe4e62bb465b28956200dec419c158)
+ - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-17e7fc9ed1291f3c3a332e54b65762dcac73f699)
+ - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-0f3d53dc1ff728a9ee7518e0ad5992c1fedcb7ff)
  - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-63e3151ce39b028bb15225d8305e8ae59d1d2b9c)
- - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-65a45dfeaa613598d736e8e631a8900b78e3c9ff)
- - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-66caea638b41f99f47c90fbf9f08a165f7bc312b)
- - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-c8cde8c39dee0b427f9770e8e63ece827cebac04)
- - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-c9b71dbef4490527107a1dcfcd38f77b374c74d5)
- - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-dcdaa0d007eeecd45a7d5ac2cf47b91d52c07fc8)
+ - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-33b751b1c6fcaa79a1f249d90774c58df3a3146f)
  - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-ed3f9fc9cd17f66b01b08112c1a1c0eb063dfbc7)
+ - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-c8cde8c39dee0b427f9770e8e63ece827cebac04)
+ - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-1800a4c4e6451dd14c0759f41c3b260e10010627)
+ - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-dcdaa0d007eeecd45a7d5ac2cf47b91d52c07fc8)
+ - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-c9b71dbef4490527107a1dcfcd38f77b374c74d5)
+ - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-66caea638b41f99f47c90fbf9f08a165f7bc312b)
+ - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-65a45dfeaa613598d736e8e631a8900b78e3c9ff)
 
 
 **operator./=**:
@@ -2627,41 +2627,41 @@ pagetitle: Alphabetical Index
 
 **operator.^**:
 
- - [`( complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-091231072e09466bffb7f4aad16c86348a965b44)
  - [`( complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-1e6130ad7edcc189ada93ab46995b79b280ada4d)
- - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-4d24b6cb15adf28b25dc40a155bf4c76980d37d0)
- - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-875148aa0d5deecb6b31fecb24608a167d02fa95)
- - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-a7f9b0419a421d43341556c8b8823bb6737fa14c)
- - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-af111e3482f1da8bfba4fa5bae01a0084ebebca3)
- - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-ba84dc5cb8e20d287fb783ebc26ecf24df38f043)
- - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-fa71ce75b9e1f602439d979ae6e9a6161effce6d)
+ - [`( complex_matrix x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-091231072e09466bffb7f4aad16c86348a965b44)
  - [`(complex x, complex_matrix y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-fd8c739930b5a8f56920738e91cec159c5e50783)
- - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-1d5f88db2e08d98185f4bdad36ccdeb289d1a58c)
- - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-257383daeef20f4a85bd2e23e4f3c9c2ecfb013d)
- - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-396441e397b74d06863454c78d4b5af50dda330f)
- - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-71f690034947993173f537ecaa9c8ee8a6e8c1e8)
- - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-8955da8055e2b2a58a20eac3964a35cdf330b786)
- - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-9f9fe3db8b2a57c2c414d4efe2eb5aa93b6b86e4)
- - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-a4fdb1f768269d25cc5aab5dafbe0535c73ee226)
- - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-ea70cfe8f041b8cdd5f8cfcc99356a42ca783deb)
+ - [`(complex x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-fa71ce75b9e1f602439d979ae6e9a6161effce6d)
+ - [`(complex x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-af111e3482f1da8bfba4fa5bae01a0084ebebca3)
+ - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-875148aa0d5deecb6b31fecb24608a167d02fa95)
+ - [`(complex_row_vector x, complex_row_vector y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-ba84dc5cb8e20d287fb783ebc26ecf24df38f043)
+ - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-a7f9b0419a421d43341556c8b8823bb6737fa14c)
+ - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-4d24b6cb15adf28b25dc40a155bf4c76980d37d0)
  - [`(matrix x, matrix y) : matrix`](matrix_operations.qmd#index-entry-ee33dd887a5da3fafc96e59aa3cd75c6d5051cea)
+ - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-1d5f88db2e08d98185f4bdad36ccdeb289d1a58c)
+ - [`(real x, matrix y) : matrix`](matrix_operations.qmd#index-entry-8955da8055e2b2a58a20eac3964a35cdf330b786)
+ - [`(real x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-ea70cfe8f041b8cdd5f8cfcc99356a42ca783deb)
+ - [`(real x, vector y) : vector`](matrix_operations.qmd#index-entry-396441e397b74d06863454c78d4b5af50dda330f)
+ - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-257383daeef20f4a85bd2e23e4f3c9c2ecfb013d)
+ - [`(row_vector x, row_vector y) : row_vector`](matrix_operations.qmd#index-entry-a4fdb1f768269d25cc5aab5dafbe0535c73ee226)
+ - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-9f9fe3db8b2a57c2c414d4efe2eb5aa93b6b86e4)
+ - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-71f690034947993173f537ecaa9c8ee8a6e8c1e8)
 
 
 **operator/**:
 
  - [`(complex x, complex y) : complex`](complex-valued_basic_functions.qmd#index-entry-2982c4088224c83c22a60e3c585c997d23773024)
- - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-0042e2fa5c0ff5c4695b13b4a482a8b37f1ab450)
- - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-05c2018d6b4d3473de214d967f936575bbe2ce9e)
- - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-0e4a06f38977dd429031b5e8cbd2c34d97c11b6d)
  - [`(complex_matrix B, complex_matrix A) : complex_matrix`](complex_matrix_operations.qmd#index-entry-469c065cfa735cf1880ee348a7459ff469411426)
+ - [`(complex_matrix x, complex y) : complex_matrix`](complex_matrix_operations.qmd#index-entry-0e4a06f38977dd429031b5e8cbd2c34d97c11b6d)
  - [`(complex_row_vector b, complex_matrix A) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-f47bdbfb8220a45ba54119c3805497e1d4596752)
+ - [`(complex_row_vector x, complex y) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-05c2018d6b4d3473de214d967f936575bbe2ce9e)
+ - [`(complex_vector x, complex y) : complex_vector`](complex_matrix_operations.qmd#index-entry-0042e2fa5c0ff5c4695b13b4a482a8b37f1ab450)
  - [`(int x, int y) : int`](integer-valued_basic_functions.qmd#index-entry-4ae4285a5c320ab57f323608bdfa3c237c8e33e8)
- - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-31c5a97eb5a6aa036118bd60ae51ce6f8d86c465)
- - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-6ad75a35e6fb68d75c09604b3945b20cc0dabb1e)
  - [`(matrix B, matrix A) : matrix`](matrix_operations.qmd#index-entry-aa2855d27dc938ec16cafecff875185e51ba660d)
- - [`(row_vector b, matrix A) : row_vector`](matrix_operations.qmd#index-entry-c8f636c70157ca03f436fa1fa6ad66005ee280c7)
  - [`(matrix x, real y) : matrix`](matrix_operations.qmd#index-entry-dc385d6a823b14919aaa86e64b873846b31b422b)
  - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-b28e30b8930bb68726d2de15d2857875cb73fcfb)
+ - [`(row_vector b, matrix A) : row_vector`](matrix_operations.qmd#index-entry-c8f636c70157ca03f436fa1fa6ad66005ee280c7)
+ - [`(row_vector x, real y) : row_vector`](matrix_operations.qmd#index-entry-6ad75a35e6fb68d75c09604b3945b20cc0dabb1e)
+ - [`(vector x, real y) : vector`](matrix_operations.qmd#index-entry-31c5a97eb5a6aa036118bd60ae51ce6f8d86c465)
 
 
 **operator/=**:
@@ -2672,8 +2672,8 @@ pagetitle: Alphabetical Index
 
 **operator<**:
 
- - [`(real x, real y) : int`](real-valued_basic_functions.qmd#index-entry-45d9721208dde1bade759d23819a2a80bbde7bb0)
  - [`(int x, int y) : int`](real-valued_basic_functions.qmd#index-entry-eb4fbef11b05d04b29b1d9b813f5e07945bf9ad8)
+ - [`(real x, real y) : int`](real-valued_basic_functions.qmd#index-entry-45d9721208dde1bade759d23819a2a80bbde7bb0)
 
 
 **operator<=**:
@@ -2696,14 +2696,14 @@ pagetitle: Alphabetical Index
 
 **operator>**:
 
- - [`(real x, real y) : int`](real-valued_basic_functions.qmd#index-entry-47bdb3c70b9ec7cdf0f976442ca728e5cd85ea39)
  - [`(int x, int y) : int`](real-valued_basic_functions.qmd#index-entry-7897823400bd03a18304e92dea188037789e2fc0)
+ - [`(real x, real y) : int`](real-valued_basic_functions.qmd#index-entry-47bdb3c70b9ec7cdf0f976442ca728e5cd85ea39)
 
 
 **operator>=**:
 
- - [`(real x, real y) : int`](real-valued_basic_functions.qmd#index-entry-29ba70695594992fa689387dd1f623e794aa8ef2)
  - [`(int x, int y) : int`](real-valued_basic_functions.qmd#index-entry-9d2656ef1df47087d225d2cfd011938c49677d09)
+ - [`(real x, real y) : int`](real-valued_basic_functions.qmd#index-entry-29ba70695594992fa689387dd1f623e794aa8ef2)
 
 
 **operator\\**:
@@ -2731,18 +2731,18 @@ pagetitle: Alphabetical Index
 
 **ordered_logistic_glm_lpmf**:
 
- - [`(array[] int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-13f1725d36ca9cd5b34e0f7533be511bf7a2ec70)
- - [`(int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-2c635de14c16f079f1741deefe7257e6a42810dc)
- - [`(int y | matrix x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-c11116cef97e5808f28ca2124ff702866ce897e4)
  - [`(array[] int y | matrix x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-c3713f9c51b422f753ef46eab1b6000b57a85f83)
+ - [`(array[] int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-13f1725d36ca9cd5b34e0f7533be511bf7a2ec70)
+ - [`(int y | matrix x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-c11116cef97e5808f28ca2124ff702866ce897e4)
+ - [`(int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-2c635de14c16f079f1741deefe7257e6a42810dc)
 
 
 **ordered_logistic_glm_lupmf**:
 
- - [`(array[] int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-1c7b2fb2eee1fbd25742cd97c0396297b00db969)
  - [`(array[] int y | matrix x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-55686d3ab941df81acce76e8e1f880716336638b)
- - [`(int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-5c21721436d27b4570a4356fcf87939c6695e2bc)
+ - [`(array[] int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-1c7b2fb2eee1fbd25742cd97c0396297b00db969)
  - [`(int y | matrix x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-757d0591bda8f231fba81cb4faa1d71ba85deb4f)
+ - [`(int y | row_vector x, vector beta, vector c) : real`](bounded_discrete_distributions.qmd#index-entry-5c21721436d27b4570a4356fcf87939c6695e2bc)
 
 
 **ordered_logistic_lpmf**:
@@ -2907,22 +2907,22 @@ pagetitle: Alphabetical Index
 
 **poisson_log_glm_lpmf**:
 
- - [`(array[] int y | row_vector x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-5edf084bfc5e8e7f2942c123d2485b9947832b4a)
- - [`(int y | matrix x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-63439a9c4647ac7c084fdb2e91704175532de973)
- - [`(int y | matrix x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-809af19433732f5658706fbd90b7e3489497b084)
- - [`(array[] int y | row_vector x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-83fff7e4697319fe19b71c0eecbdf5ac8049b7cb)
  - [`(array[] int y | matrix x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-9ccc16b1cd683cb83b9f375ecf6d419b4b28ad2e)
  - [`(array[] int y | matrix x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-eba869933862786def5f0691fd7751eeb0de388f)
+ - [`(array[] int y | row_vector x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-5edf084bfc5e8e7f2942c123d2485b9947832b4a)
+ - [`(array[] int y | row_vector x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-83fff7e4697319fe19b71c0eecbdf5ac8049b7cb)
+ - [`(int y | matrix x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-63439a9c4647ac7c084fdb2e91704175532de973)
+ - [`(int y | matrix x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-809af19433732f5658706fbd90b7e3489497b084)
 
 
 **poisson_log_glm_lupmf**:
 
- - [`(array[] int y | row_vector x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-279c01365489bac4622e7dcfcc8075202555568c)
- - [`(int y | matrix x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-8754addaa08a378fc56a498e81745574e870f6fb)
  - [`(array[] int y | matrix x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-a22ac3bb5bf0da63d28e08cceb394ea47b6f355b)
  - [`(array[] int y | matrix x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-edf1d3e6f8239fe43a077fe8e6dfdb7735799c66)
- - [`(int y | matrix x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-f122468454f01edf31a51909ec8967c9de864cf3)
+ - [`(array[] int y | row_vector x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-279c01365489bac4622e7dcfcc8075202555568c)
  - [`(array[] int y | row_vector x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-f817a209ecaeb8259b7e13294695ad91e1bac17b)
+ - [`(int y | matrix x, real alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-f122468454f01edf31a51909ec8967c9de864cf3)
+ - [`(int y | matrix x, vector alpha, vector beta) : real`](unbounded_discrete_distributions.qmd#index-entry-8754addaa08a378fc56a498e81745574e870f6fb)
 
 
 **poisson_log_lpmf**:
@@ -2967,10 +2967,10 @@ pagetitle: Alphabetical Index
 
 **pow**:
 
- - [`(T1 x, T2 y) : Z`](complex-valued_basic_functions.qmd#index-entry-24c507386fa0ba9857a2bc0d50a9e2553e9ceba6)
  - [`(complex x, complex y) : complex`](complex-valued_basic_functions.qmd#index-entry-a687c481b458dcd50e13b27c0423402b6332fc08)
  - [`(real x, real y) : real`](real-valued_basic_functions.qmd#index-entry-0882f3a0b5f515684dd2a29821a274a09ada9426)
  - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-c9ec850adf117cff8e4f8da2a8287b92a152b481)
+ - [`(T1 x, T2 y) : Z`](complex-valued_basic_functions.qmd#index-entry-24c507386fa0ba9857a2bc0d50a9e2553e9ceba6)
 
 
 **print**:
@@ -2982,12 +2982,12 @@ pagetitle: Alphabetical Index
 
  - [`(array[] int x) : real`](array_operations.qmd#index-entry-69d45ac78302f42fc87a23263c5230e4ee093a6e)
  - [`(array[] real x) : real`](array_operations.qmd#index-entry-936503ecb56cc2f9aa31395e3b80d5dd901f14ab)
- - [`(complex_vector x) : complex`](complex_matrix_operations.qmd#index-entry-12d6f5e8068b2b8308d32394e6debc2fa118e082)
  - [`(complex_matrix x) : complex`](complex_matrix_operations.qmd#index-entry-2c4545b2f6cd6bbf4e42a4d446d210160e082d42)
  - [`(complex_row_vector x) : complex`](complex_matrix_operations.qmd#index-entry-5353a09f94f67878ef023d0c25bdf91d78c1cfaa)
- - [`(vector x) : real`](matrix_operations.qmd#index-entry-9713d871d72b91892fb1be528d008fcb62d40ba7)
+ - [`(complex_vector x) : complex`](complex_matrix_operations.qmd#index-entry-12d6f5e8068b2b8308d32394e6debc2fa118e082)
  - [`(matrix x) : real`](matrix_operations.qmd#index-entry-b45dad30f80e5937e91c940a770331aae131753c)
  - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-c081c52af0fe73a003a0a406a8378cde350a34bf)
+ - [`(vector x) : real`](matrix_operations.qmd#index-entry-9713d871d72b91892fb1be528d008fcb62d40ba7)
 
 
 **proj**:
@@ -3041,26 +3041,26 @@ pagetitle: Alphabetical Index
 
 **quad_form_sym**:
 
- - [`(matrix A, vector B) : real`](matrix_operations.qmd#index-entry-362d5553d7ff140b2163b35fed3667b17ad4c3d3)
  - [`(matrix A, matrix B) : matrix`](matrix_operations.qmd#index-entry-cb6d97ec303631d01e1fbf4737567987878d14b2)
+ - [`(matrix A, vector B) : real`](matrix_operations.qmd#index-entry-362d5553d7ff140b2163b35fed3667b17ad4c3d3)
 
 
 **quantile**:
 
- - [`(data array[] real x, data real p) : real`](array_operations.qmd#index-entry-8c7df96194aa20f4691df231ed7577942daf6d6f)
  - [`(data array[] real x, data array[] real p) : array[] real`](array_operations.qmd#index-entry-b0471485d6b0fd5b43b349cbe4e386d6c38f5064)
+ - [`(data array[] real x, data real p) : real`](array_operations.qmd#index-entry-8c7df96194aa20f4691df231ed7577942daf6d6f)
+ - [`(data row_vector x, data array[] real p) : array[] real`](matrix_operations.qmd#index-entry-ba154b25a2265003899559c90fe541c3a07a82e0)
+ - [`(data row_vector x, data real p) : real`](matrix_operations.qmd#index-entry-5ca7a0e8fda0d0ac93828d2154479406eead9a61)
  - [`(data vector x, data array[] real p) : array[] real`](matrix_operations.qmd#index-entry-49b22dc2be74bb430f6e2faee8a2f6985280f397)
  - [`(data vector x, data real p) : real`](matrix_operations.qmd#index-entry-5bcb3bb3e5ae7f0a50cf00b2fb37cc35759014da)
- - [`(data row_vector x, data real p) : real`](matrix_operations.qmd#index-entry-5ca7a0e8fda0d0ac93828d2154479406eead9a61)
- - [`(data row_vector x, data array[] real p) : array[] real`](matrix_operations.qmd#index-entry-ba154b25a2265003899559c90fe541c3a07a82e0)
 
 
 
 ## R
 **rank**:
 
- - [`(array[] real v, int s) : int`](array_operations.qmd#index-entry-a28838301370f881f9ec571b8676f50b783b629c)
  - [`(array[] int v, int s) : int`](array_operations.qmd#index-entry-a6d0770a4ab5bc51a44d3626199ee7de7658377e)
+ - [`(array[] real v, int s) : int`](array_operations.qmd#index-entry-a28838301370f881f9ec571b8676f50b783b629c)
  - [`(row_vector v, int s) : int`](matrix_operations.qmd#index-entry-9dc76dd605fabb78a31bc22a4cbc3bba0371758d)
  - [`(vector v, int s) : int`](matrix_operations.qmd#index-entry-a2612df2dc4076d90d32d7205a10905c38bcb241)
 
@@ -3120,11 +3120,11 @@ pagetitle: Alphabetical Index
 **rep_matrix**:
 
  - [`(complex z, int m, int n) : complex_matrix`](complex_matrix_operations.qmd#index-entry-24c948121a2ee087e060ad1257d8719e1b9aa2c3)
- - [`(complex_vector v, int n) : complex_matrix`](complex_matrix_operations.qmd#index-entry-680d23b80116edb9e6752b03801cf43a42571d6a)
  - [`(complex_row_vector rv, int m) : complex_matrix`](complex_matrix_operations.qmd#index-entry-e106eee17c0bdf0c73908ed222c19f595e566330)
- - [`(vector v, int n) : matrix`](matrix_operations.qmd#index-entry-9088cad16f7504b9acf856be4fc670b42cbd9eaa)
- - [`(row_vector rv, int m) : matrix`](matrix_operations.qmd#index-entry-a54769495396ea1427a26c419009fcf4b6b69cbf)
+ - [`(complex_vector v, int n) : complex_matrix`](complex_matrix_operations.qmd#index-entry-680d23b80116edb9e6752b03801cf43a42571d6a)
  - [`(real x, int m, int n) : matrix`](matrix_operations.qmd#index-entry-f6dac444f76cc32475bbb31cceff748d10649662)
+ - [`(row_vector rv, int m) : matrix`](matrix_operations.qmd#index-entry-a54769495396ea1427a26c419009fcf4b6b69cbf)
+ - [`(vector v, int n) : matrix`](matrix_operations.qmd#index-entry-9088cad16f7504b9acf856be4fc670b42cbd9eaa)
 
 
 **rep_row_vector**:
@@ -3142,16 +3142,16 @@ pagetitle: Alphabetical Index
 **reverse**:
 
  - [`(array[] T v) : array[] T`](array_operations.qmd#index-entry-9759b3b50ddba20806c98d04d90c234afd5b230e)
- - [`(complex_vector v) : complex_vector`](complex_matrix_operations.qmd#index-entry-4967c86d60f1814cc9c1b26860a5b0a2d875cfa6)
  - [`(complex_row_vector v) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-6518a921f55ed48810b7eddb6fdeebc850a60c27)
- - [`(vector v) : vector`](matrix_operations.qmd#index-entry-568dc0f51c2d88dc59f98ff0b5cf0080469ad789)
+ - [`(complex_vector v) : complex_vector`](complex_matrix_operations.qmd#index-entry-4967c86d60f1814cc9c1b26860a5b0a2d875cfa6)
  - [`(row_vector v) : row_vector`](matrix_operations.qmd#index-entry-6b1f33889b3d5f2093ad7854f2692c91b8adcd02)
+ - [`(vector v) : vector`](matrix_operations.qmd#index-entry-568dc0f51c2d88dc59f98ff0b5cf0080469ad789)
 
 
 **rising_factorial**:
 
- - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-1908eb05437a542da8fa4551ec25c60d068905cb)
  - [`(real x, int n) : real`](real-valued_basic_functions.qmd#index-entry-740279c8bcb940f23acd2a981763223a674105b8)
+ - [`(T1 x, T2 y) : R`](real-valued_basic_functions.qmd#index-entry-1908eb05437a542da8fa4551ec25c60d068905cb)
 
 
 **round**:
@@ -3167,32 +3167,32 @@ pagetitle: Alphabetical Index
 
 **rows**:
 
- - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-8005f2c9cb8700f40b7a2aa479a6d62cc1ab309d)
  - [`(complex_matrix x) : int`](complex_matrix_operations.qmd#index-entry-9ebbc38c2cab2bb85fc80a2aace93188ecfcf794)
  - [`(complex_row_vector x) : int`](complex_matrix_operations.qmd#index-entry-e14fb4048c19b782910ef083ea77519d2136be69)
- - [`(row_vector x) : int`](matrix_operations.qmd#index-entry-578ea4c98303c7c7498cb69c853a18e09d5c44fd)
+ - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-8005f2c9cb8700f40b7a2aa479a6d62cc1ab309d)
  - [`(matrix x) : int`](matrix_operations.qmd#index-entry-65ffc1cace11a1dd2675fb84a331101e1ea8b626)
+ - [`(row_vector x) : int`](matrix_operations.qmd#index-entry-578ea4c98303c7c7498cb69c853a18e09d5c44fd)
  - [`(vector x) : int`](matrix_operations.qmd#index-entry-c6697d2988eb22bf8fd56b05ffcde6779627ebf8)
 
 
 **rows_dot_product**:
 
- - [`(complex_row_vector x, complex_row_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-734a199664218183d672f594e0ba3c472067cf38)
  - [`(complex_matrix x, complex_matrix y) : complex_vector`](complex_matrix_operations.qmd#index-entry-74d6233826ba207dc78ce8fa7c02a1177299542d)
+ - [`(complex_row_vector x, complex_row_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-734a199664218183d672f594e0ba3c472067cf38)
  - [`(complex_vector x, complex_vector y) : complex_vector`](complex_matrix_operations.qmd#index-entry-9869bbad286feb6e3252d28a43fac51f950044c7)
- - [`(row_vector x, row_vector y) : vector`](matrix_operations.qmd#index-entry-9bb7b3a8ee495648abc1b0eff2ecebe52c99be25)
  - [`(matrix x, matrix y) : vector`](matrix_operations.qmd#index-entry-cf6ee59a255f43dac007f4dd3ef01a1119343cb0)
+ - [`(row_vector x, row_vector y) : vector`](matrix_operations.qmd#index-entry-9bb7b3a8ee495648abc1b0eff2ecebe52c99be25)
  - [`(vector x, vector y) : vector`](matrix_operations.qmd#index-entry-de1fe07c43494dac868152a24e25fcf81955732e)
 
 
 **rows_dot_self**:
 
  - [`(complex_matrix x) : complex_vector`](complex_matrix_operations.qmd#index-entry-771452c2e576061539abb7bece2cec0051b51eb7)
- - [`(complex_vector x) : complex_vector`](complex_matrix_operations.qmd#index-entry-9089a74ceffaf17dbabc8404c8575d1f4d6f92a9)
  - [`(complex_row_vector x) : complex_vector`](complex_matrix_operations.qmd#index-entry-f485e7669d290a4148d1373c4705206fdef737e3)
+ - [`(complex_vector x) : complex_vector`](complex_matrix_operations.qmd#index-entry-9089a74ceffaf17dbabc8404c8575d1f4d6f92a9)
  - [`(matrix x) : vector`](matrix_operations.qmd#index-entry-947ee99ec791f7bead5c155ced2ef89e5ac7e8b7)
- - [`(vector x) : vector`](matrix_operations.qmd#index-entry-a451434f24e97a590c47f3f0e691af26a61e8705)
  - [`(row_vector x) : vector`](matrix_operations.qmd#index-entry-b624c89d6c4d2e43359ff78346c37076b91730f1)
+ - [`(vector x) : vector`](matrix_operations.qmd#index-entry-a451434f24e97a590c47f3f0e691af26a61e8705)
 
 
 
@@ -3240,16 +3240,16 @@ pagetitle: Alphabetical Index
 **sd**:
 
  - [`(array[] real x) : real`](array_operations.qmd#index-entry-2ff81571d634ef5353d30cfebadc9561bf519ee4)
+ - [`(matrix x) : real`](matrix_operations.qmd#index-entry-8af54c041853b0f940ca2f60a845500498fdcf2b)
  - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-0182a4edcf541473e053aff58f5a7d2eafa83574)
  - [`(vector x) : real`](matrix_operations.qmd#index-entry-41a7ec70ca2889f5e84fd426dfa08137bfaba28a)
- - [`(matrix x) : real`](matrix_operations.qmd#index-entry-8af54c041853b0f940ca2f60a845500498fdcf2b)
 
 
 **segment**:
 
- - [`(complex_vector v, int i, int n) : complex_vector`](complex_matrix_operations.qmd#index-entry-96d8e2e13f7a5c50b4fef83a87ac1dcd395ab08f)
- - [`(complex_row_vector rv, int i, int n) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-b59ddb42d7b01c4f637d83f1654f9b63e6f1d9cd)
  - [`(array[] T sv, int i, int n) : array[] T`](matrix_operations.qmd#index-entry-2374a68547cdedbbdfbb1b7212dd1ccaf48d84b3)
+ - [`(complex_row_vector rv, int i, int n) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-b59ddb42d7b01c4f637d83f1654f9b63e6f1d9cd)
+ - [`(complex_vector v, int i, int n) : complex_vector`](complex_matrix_operations.qmd#index-entry-96d8e2e13f7a5c50b4fef83a87ac1dcd395ab08f)
  - [`(row_vector rv, int i, int n) : row_vector`](matrix_operations.qmd#index-entry-26587b215542055b9fe52316209a88041c119b87)
  - [`(vector v, int i, int n) : vector`](matrix_operations.qmd#index-entry-71cb7ac02f1e74f4b6fff77caa9b5ef0bd15346a)
 
@@ -3275,14 +3275,14 @@ pagetitle: Alphabetical Index
 **size**:
 
  - [`(array[] T x) : int`](array_operations.qmd#index-entry-c12761833dc86f2313582b4fe440b0b82d4c8cb6)
- - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-4a14d6b215559d7664aabfafde37e9153206b209)
- - [`(matrix x) : int`](complex_matrix_operations.qmd#index-entry-69098855a034f282c0294e1c6c21cded79ec8a3c)
  - [`(complex_row_vector x) : int`](complex_matrix_operations.qmd#index-entry-dd6512340d46b06fe64606e36622bf23ed255eab)
+ - [`(complex_vector x) : int`](complex_matrix_operations.qmd#index-entry-4a14d6b215559d7664aabfafde37e9153206b209)
  - [`(int x) : int`](integer-valued_basic_functions.qmd#index-entry-cc587d014dd8cd99986939af8ad1854a3c3425f0)
- - [`(real x) : int`](integer-valued_basic_functions.qmd#index-entry-f9c96384668fa7a7880511c2c0ad2558be24e0a4)
  - [`(matrix x) : int`](matrix_operations.qmd#index-entry-69098855a034f282c0294e1c6c21cded79ec8a3c)
- - [`(vector x) : int`](matrix_operations.qmd#index-entry-9b99cb12fadc8373556db600c949cc44b43fe907)
+ - [`(matrix x) : int`](complex_matrix_operations.qmd#index-entry-69098855a034f282c0294e1c6c21cded79ec8a3c)
+ - [`(real x) : int`](integer-valued_basic_functions.qmd#index-entry-f9c96384668fa7a7880511c2c0ad2558be24e0a4)
  - [`(row_vector x) : int`](matrix_operations.qmd#index-entry-f449c3a25c74efefc2c1462cf914a52a4050d575)
+ - [`(vector x) : int`](matrix_operations.qmd#index-entry-9b99cb12fadc8373556db600c949cc44b43fe907)
 
 
 **skew_double_exponential**:
@@ -3362,10 +3362,10 @@ pagetitle: Alphabetical Index
 
 **sort_asc**:
 
- - [`(array[] real v) : array[] real`](array_operations.qmd#index-entry-29411da2ef662a3af3793ab20c89f7e7b677bd0e)
  - [`(array[] int v) : array[] int`](array_operations.qmd#index-entry-6e75416be841609073a75454c55e2fbc19f46f47)
- - [`(vector v) : vector`](matrix_operations.qmd#index-entry-3f7cd093f7a97b178afa3f28332faee31600a6c9)
+ - [`(array[] real v) : array[] real`](array_operations.qmd#index-entry-29411da2ef662a3af3793ab20c89f7e7b677bd0e)
  - [`(row_vector v) : row_vector`](matrix_operations.qmd#index-entry-9bc88f386e57fb9d4e7a2e0fd914d4525b7271c8)
+ - [`(vector v) : vector`](matrix_operations.qmd#index-entry-3f7cd093f7a97b178afa3f28332faee31600a6c9)
 
 
 **sort_desc**:
@@ -3410,10 +3410,10 @@ pagetitle: Alphabetical Index
 
 **squared_distance**:
 
- - [`(vector x, vector y) : real`](array_operations.qmd#index-entry-47ca27c5ccd71b8bebcadb9723ea604c50120857)
  - [`(row_vector x, row_vector y) : real`](array_operations.qmd#index-entry-794d03938547aad86944e55cbb1f64f9ea22dee5)
  - [`(row_vector x, vector y) : real`](array_operations.qmd#index-entry-8887aa905b17d368550a915063d1bb8fbf4ccf59)
  - [`(vector x, row_vector y) : real`](array_operations.qmd#index-entry-e2cb205544293c316ec3e5356c4d1dbebfafb159)
+ - [`(vector x, vector y) : real`](array_operations.qmd#index-entry-47ca27c5ccd71b8bebcadb9723ea604c50120857)
 
 
 **std_normal**:
@@ -3515,14 +3515,14 @@ pagetitle: Alphabetical Index
 
 **sum**:
 
- - [`(array[] real x) : real`](array_operations.qmd#index-entry-acfd44849111bfa6024f821401db39f1181f4d14)
- - [`(array[] int x) : int`](array_operations.qmd#index-entry-d97ce537eae8d48ac3ddc98520d0c5eaafd6fe27)
  - [`(array[] complex x) : complex`](array_operations.qmd#index-entry-e7ecc93be79d76e228adf2a4a2f9cdd908a7238b)
+ - [`(array[] int x) : int`](array_operations.qmd#index-entry-d97ce537eae8d48ac3ddc98520d0c5eaafd6fe27)
+ - [`(array[] real x) : real`](array_operations.qmd#index-entry-acfd44849111bfa6024f821401db39f1181f4d14)
  - [`(complex_matrix x) : complex`](complex_matrix_operations.qmd#index-entry-3cba7a8e0e6f9daf41a8ac994c85688f887c228b)
- - [`(complex_vector x) : complex`](complex_matrix_operations.qmd#index-entry-3cf6379c6f6f87df7a312af029238c24af388e45)
  - [`(complex_row_vector x) : complex`](complex_matrix_operations.qmd#index-entry-bbcdf1952ec801328e03cb3637166b7a9f2f3cff)
- - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-6e609b116c423a798df7d214f82a296fb3c45baa)
+ - [`(complex_vector x) : complex`](complex_matrix_operations.qmd#index-entry-3cf6379c6f6f87df7a312af029238c24af388e45)
  - [`(matrix x) : real`](matrix_operations.qmd#index-entry-7a966705e2b5c7762ea80adedd66384f947e0d59)
+ - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-6e609b116c423a798df7d214f82a296fb3c45baa)
  - [`(vector x) : real`](matrix_operations.qmd#index-entry-a3848926d02b63042a5cca7f5f2114a98d5a3b54)
 
 
@@ -3554,9 +3554,9 @@ pagetitle: Alphabetical Index
 ## T
 **tail**:
 
+ - [`(array[] T sv, int n) : array[] T`](matrix_operations.qmd#index-entry-4cdc4c7bbfd1b9012474960694df39fd3ac0bd73)
  - [`(complex_row_vector rv, int n) : complex_row_vector`](complex_matrix_operations.qmd#index-entry-104f1db13950e7c221c9ce66c329f9ebb415fbe2)
  - [`(complex_vector v, int n) : complex_vector`](complex_matrix_operations.qmd#index-entry-5072d264c287300a4f02919b52048769218f5864)
- - [`(array[] T sv, int n) : array[] T`](matrix_operations.qmd#index-entry-4cdc4c7bbfd1b9012474960694df39fd3ac0bd73)
  - [`(row_vector rv, int n) : row_vector`](matrix_operations.qmd#index-entry-aa91264e50992aae5e2a411f1e27c3136e23148a)
  - [`(vector v, int n) : vector`](matrix_operations.qmd#index-entry-c59d1ebbba5b4cd5cf3ff22130cb426b46df662a)
 
@@ -3590,28 +3590,28 @@ pagetitle: Alphabetical Index
 
 **to_array_1d**:
 
- - [`(complex_vector v) : array[] real`](mixed_operations.qmd#index-entry-242195f746365e4ab07756d8dfc2d627d760131c)
- - [`(vector v) : array[] real`](mixed_operations.qmd#index-entry-2f5e845bb7c1046346206e70df45afa871d3bbca)
- - [`(complex_matrix m) : array[] complex`](mixed_operations.qmd#index-entry-841e76b5eb14b885bfb8ea725edd4531171d3dc7)
- - [`(matrix m) : array[] real`](mixed_operations.qmd#index-entry-89bbd3b92786cfeacbc58a9b8e1815eb4704fe94)
- - [`(complex_row_vector v) : array[] complex`](mixed_operations.qmd#index-entry-9dbf7ca0cd05cc0137132abe8de599edc8db6fb6)
  - [`(array[...] complex a) : array[] complex`](mixed_operations.qmd#index-entry-a283222b01f625bc6705e111e10bdc2759e3d24c)
- - [`(array[...] real a) : array[] real`](mixed_operations.qmd#index-entry-d4bca2f4496bd91a3f19415933ba8d5dee724894)
- - [`(row_vector v) : array[] real`](mixed_operations.qmd#index-entry-d5e3525dd3b1532ec70529a13582b2ac5684b7a4)
  - [`(array[...] int a) : array[] int`](mixed_operations.qmd#index-entry-febcf6672aef91647fe55778211ffd168082990f)
+ - [`(array[...] real a) : array[] real`](mixed_operations.qmd#index-entry-d4bca2f4496bd91a3f19415933ba8d5dee724894)
+ - [`(complex_matrix m) : array[] complex`](mixed_operations.qmd#index-entry-841e76b5eb14b885bfb8ea725edd4531171d3dc7)
+ - [`(complex_row_vector v) : array[] complex`](mixed_operations.qmd#index-entry-9dbf7ca0cd05cc0137132abe8de599edc8db6fb6)
+ - [`(complex_vector v) : array[] real`](mixed_operations.qmd#index-entry-242195f746365e4ab07756d8dfc2d627d760131c)
+ - [`(matrix m) : array[] real`](mixed_operations.qmd#index-entry-89bbd3b92786cfeacbc58a9b8e1815eb4704fe94)
+ - [`(row_vector v) : array[] real`](mixed_operations.qmd#index-entry-d5e3525dd3b1532ec70529a13582b2ac5684b7a4)
+ - [`(vector v) : array[] real`](mixed_operations.qmd#index-entry-2f5e845bb7c1046346206e70df45afa871d3bbca)
 
 
 **to_array_2d**:
 
- - [`(matrix m) : array[,] real`](mixed_operations.qmd#index-entry-1523c6dc72269a2b99daf2481a6f15790faf2dd7)
  - [`(complex_matrix m) : array[,] real`](mixed_operations.qmd#index-entry-67b1d2f656b711d5b1f916e3e04e26038c9d38d6)
+ - [`(matrix m) : array[,] real`](mixed_operations.qmd#index-entry-1523c6dc72269a2b99daf2481a6f15790faf2dd7)
 
 
 **to_complex**:
 
+ - [`() : complex`](complex-valued_basic_functions.qmd#index-entry-a10094b116ddff99cf1ba20f448c331b23a70d51)
  - [`(real re) : complex`](complex-valued_basic_functions.qmd#index-entry-8cc4a1be479f01313e354510097189d0ab95da1a)
  - [`(real re, real im) : complex`](complex-valued_basic_functions.qmd#index-entry-982b3b69d3e75c559ef3cada7b1212eecc087fac)
- - [`() : complex`](complex-valued_basic_functions.qmd#index-entry-a10094b116ddff99cf1ba20f448c331b23a70d51)
  - [`(T1 re, T2 im) : Z`](complex-valued_basic_functions.qmd#index-entry-e003c1a960f7ece5344e1cd438e4a3ce92e225e9)
 
 
@@ -3622,61 +3622,61 @@ pagetitle: Alphabetical Index
 
 **to_matrix**:
 
- - [`(complex_row_vector v, int m, int n) : complex_matrix`](mixed_operations.qmd#index-entry-0b65adda0355db4bb294b2accb6ac1294603c298)
- - [`(vector v, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-0cf7e9303e3c6015089d4d776f68673d9becfe06)
- - [`(complex_matrix m) : complex_matrix`](mixed_operations.qmd#index-entry-1adffb84d0b4c5a1ad67ca2dce769cbdf687f577)
- - [`(array[] int a, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-2114a4d1eb26abd7a5a168f852fa2824b04264a7)
- - [`(complex_row_vector v, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-23ae52701cdc53e4b1252d837f1fd68b9cf3c092)
- - [`(array[] complex_row_vector vs) : complex_matrix`](mixed_operations.qmd#index-entry-30e7bab8b93cd06e7e722a69f87795853a321d6f)
- - [`(complex_vector v, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-38aaa00ecbf298c2b6ea8664028ae6e1db65995b)
+ - [`(array[,] complex a ) : complex_matrix`](mixed_operations.qmd#index-entry-e92b8a0a6976052fa8b22b2d2678e9daa1dc22b0)
  - [`(array[,] int a) : matrix`](mixed_operations.qmd#index-entry-3e8783df8a1f5a3a9252432f08e410ff98dcc3cc)
- - [`(array[] real a, int m, int n) : matrix`](mixed_operations.qmd#index-entry-437db9cf0cf2250154a98c0bdad40ed9b384a755)
- - [`(array[] row_vector vs) : matrix`](mixed_operations.qmd#index-entry-43ba4671c0aedffb35391977e1454635f31140b1)
- - [`(array[] real a, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-49a6288ee0b5970768e1b5eb800c235cdc531dcb)
- - [`(vector v) : matrix`](mixed_operations.qmd#index-entry-50fdb634f6d81eb2f8f0a2b2aba97a29cb575e69)
  - [`(array[,] real a) : matrix`](mixed_operations.qmd#index-entry-57abafe2911be5f079350cd935db3790df0e435b)
- - [`(row_vector v) : matrix`](mixed_operations.qmd#index-entry-792df8d223c6b836eee60bf39ca9d7d3f3e159b7)
- - [`(row_vector v, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-7f27f7aa2cd34abf4dc96d66caac862b24766c48)
- - [`(complex_row_vector v) : complex_matrix`](mixed_operations.qmd#index-entry-80cf0f8d6dea99916e4e16a9a5c04829bb454065)
+ - [`(array[] complex a, int m, int n) : complex_matrix`](mixed_operations.qmd#index-entry-bf764d9c03e5342181199ab42cf29145c1ad5854)
+ - [`(array[] complex a, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-cae4771e239eee8858e814def2ab98579b41b5eb)
+ - [`(array[] complex_row_vector vs) : complex_matrix`](mixed_operations.qmd#index-entry-30e7bab8b93cd06e7e722a69f87795853a321d6f)
+ - [`(array[] int a, int m, int n) : matrix`](mixed_operations.qmd#index-entry-e84dbcb742d813d14126e7e47ce17fad4d98c4ce)
+ - [`(array[] int a, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-2114a4d1eb26abd7a5a168f852fa2824b04264a7)
+ - [`(array[] real a, int m, int n) : matrix`](mixed_operations.qmd#index-entry-437db9cf0cf2250154a98c0bdad40ed9b384a755)
+ - [`(array[] real a, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-49a6288ee0b5970768e1b5eb800c235cdc531dcb)
+ - [`(array[] row_vector vs) : matrix`](mixed_operations.qmd#index-entry-43ba4671c0aedffb35391977e1454635f31140b1)
+ - [`(complex_matrix A, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-e90eb83d724da49ec11f03ab61860acf90355da5)
+ - [`(complex_matrix m) : complex_matrix`](mixed_operations.qmd#index-entry-1adffb84d0b4c5a1ad67ca2dce769cbdf687f577)
  - [`(complex_matrix M, int m, int n) : complex_matrix`](mixed_operations.qmd#index-entry-847d5e8f061de6894025068cf5f2eb0ba8215a31)
- - [`(matrix m) : matrix`](mixed_operations.qmd#index-entry-98af15f087742b3c48602bac340d541ab6538cc6)
- - [`(vector v, int m, int n) : matrix`](mixed_operations.qmd#index-entry-aed7ba7d91d4311c9ff956befae058ab2c5a56d5)
+ - [`(complex_row_vector v) : complex_matrix`](mixed_operations.qmd#index-entry-80cf0f8d6dea99916e4e16a9a5c04829bb454065)
+ - [`(complex_row_vector v, int m, int n) : complex_matrix`](mixed_operations.qmd#index-entry-0b65adda0355db4bb294b2accb6ac1294603c298)
+ - [`(complex_row_vector v, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-23ae52701cdc53e4b1252d837f1fd68b9cf3c092)
  - [`(complex_vector v) : complex_matrix`](mixed_operations.qmd#index-entry-aef6a0f55fed76a89b125774992391483f616f15)
  - [`(complex_vector v, int m, int n) : complex_matrix`](mixed_operations.qmd#index-entry-b6f6e03fe842ef9ce3d6ca9aabb56537f122d502)
- - [`(array[] complex a, int m, int n) : complex_matrix`](mixed_operations.qmd#index-entry-bf764d9c03e5342181199ab42cf29145c1ad5854)
- - [`(matrix M, int m, int n) : matrix`](mixed_operations.qmd#index-entry-c513be95c486e67bd8b313bb220e6184fea9292a)
- - [`(array[] complex a, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-cae4771e239eee8858e814def2ab98579b41b5eb)
+ - [`(complex_vector v, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-38aaa00ecbf298c2b6ea8664028ae6e1db65995b)
  - [`(matrix A, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-ce9fd0a6767674968523193f7115d495489cf449)
- - [`(array[] int a, int m, int n) : matrix`](mixed_operations.qmd#index-entry-e84dbcb742d813d14126e7e47ce17fad4d98c4ce)
- - [`(complex_matrix A, int m, int n, int col_major) : complex_matrix`](mixed_operations.qmd#index-entry-e90eb83d724da49ec11f03ab61860acf90355da5)
- - [`(array[,] complex a ) : complex_matrix`](mixed_operations.qmd#index-entry-e92b8a0a6976052fa8b22b2d2678e9daa1dc22b0)
+ - [`(matrix m) : matrix`](mixed_operations.qmd#index-entry-98af15f087742b3c48602bac340d541ab6538cc6)
+ - [`(matrix M, int m, int n) : matrix`](mixed_operations.qmd#index-entry-c513be95c486e67bd8b313bb220e6184fea9292a)
+ - [`(row_vector v) : matrix`](mixed_operations.qmd#index-entry-792df8d223c6b836eee60bf39ca9d7d3f3e159b7)
  - [`(row_vector v, int m, int n) : matrix`](mixed_operations.qmd#index-entry-ed0fbc154447855f068f1a47cdf0f67c288a21d0)
+ - [`(row_vector v, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-7f27f7aa2cd34abf4dc96d66caac862b24766c48)
+ - [`(vector v) : matrix`](mixed_operations.qmd#index-entry-50fdb634f6d81eb2f8f0a2b2aba97a29cb575e69)
+ - [`(vector v, int m, int n) : matrix`](mixed_operations.qmd#index-entry-aed7ba7d91d4311c9ff956befae058ab2c5a56d5)
+ - [`(vector v, int m, int n, int col_major) : matrix`](mixed_operations.qmd#index-entry-0cf7e9303e3c6015089d4d776f68673d9becfe06)
 
 
 **to_row_vector**:
 
- - [`(matrix m) : row_vector`](mixed_operations.qmd#index-entry-2233e067e71fece1a5091dbf29c83f891c0c53ac)
- - [`(complex_matrix m) : complex_row_vector`](mixed_operations.qmd#index-entry-48b04a9a3d0a2ba72b4564f6c56c7787d7d85a3d)
- - [`(complex_vector v) : complex_row_vector`](mixed_operations.qmd#index-entry-91aa719d0ab39507c033078fbe737e6992bf641b)
  - [`(array[] complex a) : complex_row_vector`](mixed_operations.qmd#index-entry-a7fd1cdc7869d1b6354acbb6c4d601343e80bc32)
- - [`(complex_row_vector v) : complex_row_vector`](mixed_operations.qmd#index-entry-c2aadf6729da7ef673b6e4729cd3640e7e8ff075)
- - [`(array[] real a) : row_vector`](mixed_operations.qmd#index-entry-cea7d9d7492857fd3d8ca4b00cbb08cd09beb181)
- - [`(vector v) : row_vector`](mixed_operations.qmd#index-entry-d10d7dd47bea28e9f6be7cb1fee79ba98a6291e2)
- - [`(row_vector v) : row_vector`](mixed_operations.qmd#index-entry-dd3935354cbe9c750365fa9d199935099c0fccd5)
  - [`(array[] int a) : row_vector`](mixed_operations.qmd#index-entry-dfad2435683430f7d34faf59c9ef36aaeef30c0f)
+ - [`(array[] real a) : row_vector`](mixed_operations.qmd#index-entry-cea7d9d7492857fd3d8ca4b00cbb08cd09beb181)
+ - [`(complex_matrix m) : complex_row_vector`](mixed_operations.qmd#index-entry-48b04a9a3d0a2ba72b4564f6c56c7787d7d85a3d)
+ - [`(complex_row_vector v) : complex_row_vector`](mixed_operations.qmd#index-entry-c2aadf6729da7ef673b6e4729cd3640e7e8ff075)
+ - [`(complex_vector v) : complex_row_vector`](mixed_operations.qmd#index-entry-91aa719d0ab39507c033078fbe737e6992bf641b)
+ - [`(matrix m) : row_vector`](mixed_operations.qmd#index-entry-2233e067e71fece1a5091dbf29c83f891c0c53ac)
+ - [`(row_vector v) : row_vector`](mixed_operations.qmd#index-entry-dd3935354cbe9c750365fa9d199935099c0fccd5)
+ - [`(vector v) : row_vector`](mixed_operations.qmd#index-entry-d10d7dd47bea28e9f6be7cb1fee79ba98a6291e2)
 
 
 **to_vector**:
 
- - [`(complex_matrix m) : complex_vector`](mixed_operations.qmd#index-entry-038b0de9dc724055453f09b0cbcbd18ed0b245f5)
- - [`(array[] int a) : vector`](mixed_operations.qmd#index-entry-32661d5b8760ecddd2d8777793db7ece329e55ec)
- - [`(row_vector v) : vector`](mixed_operations.qmd#index-entry-3c628a0f6a20eda39461617826fd33046b2dc1c3)
- - [`(complex_row_vector v) : complex_vector`](mixed_operations.qmd#index-entry-5976d67e9306d7472825e4d06e32e82b5c9ed3b0)
- - [`(vector v) : vector`](mixed_operations.qmd#index-entry-5eaf76d379576fc126f8cb1a1ddde01467fd11b4)
- - [`(matrix m) : vector`](mixed_operations.qmd#index-entry-6f0903591f2ae71c76fb2f1c0a3330e7a39749c3)
  - [`(array[] complex a) : complex_vector`](mixed_operations.qmd#index-entry-b7e01d700955b123c6a7d94113e75dae2182ca9d)
+ - [`(array[] int a) : vector`](mixed_operations.qmd#index-entry-32661d5b8760ecddd2d8777793db7ece329e55ec)
  - [`(array[] real a) : vector`](mixed_operations.qmd#index-entry-c912c1c0f3589db9d1a5d2bffb2b3b697c20f3d7)
+ - [`(complex_matrix m) : complex_vector`](mixed_operations.qmd#index-entry-038b0de9dc724055453f09b0cbcbd18ed0b245f5)
+ - [`(complex_row_vector v) : complex_vector`](mixed_operations.qmd#index-entry-5976d67e9306d7472825e4d06e32e82b5c9ed3b0)
  - [`(complex_vector v) : complex_vector`](mixed_operations.qmd#index-entry-d05604f9063eb5e5f46e231e2dedd8a2be6250c3)
+ - [`(matrix m) : vector`](mixed_operations.qmd#index-entry-6f0903591f2ae71c76fb2f1c0a3330e7a39749c3)
+ - [`(row_vector v) : vector`](mixed_operations.qmd#index-entry-3c628a0f6a20eda39461617826fd33046b2dc1c3)
+ - [`(vector v) : vector`](mixed_operations.qmd#index-entry-5eaf76d379576fc126f8cb1a1ddde01467fd11b4)
 
 
 **trace**:
@@ -3752,9 +3752,9 @@ pagetitle: Alphabetical Index
 **variance**:
 
  - [`(array[] real x) : real`](array_operations.qmd#index-entry-92ca3dfea614e505cf3d32942458a9c948f45e92)
- - [`(vector x) : real`](matrix_operations.qmd#index-entry-500efa24724b539cd9b32e37fb5895b0cd48f91c)
  - [`(matrix x) : real`](matrix_operations.qmd#index-entry-a59da01b6e381f01f0c9a08137440eea6455a2a2)
  - [`(row_vector x) : real`](matrix_operations.qmd#index-entry-f595237eba9511d08bff024bd377900cc94e0c62)
+ - [`(vector x) : real`](matrix_operations.qmd#index-entry-500efa24724b539cd9b32e37fb5895b0cd48f91c)
 
 
 **von_mises**:
@@ -3836,11 +3836,15 @@ pagetitle: Alphabetical Index
 
 **wiener_lpdf**:
 
+ - [`(real y | real alpha, real tau, real beta, real delta, real var_delta) : real`](positive_lower-bounded_distributions.qmd#index-entry-dd5110522b6a5fb9baac9dab11ad3dca296d7a24)
+ - [`(real y | real alpha, real tau, real beta, real delta, real var_delta, real var_beta, real var_tau) : real`](positive_lower-bounded_distributions.qmd#index-entry-60f0354d0a8198be7994a9f5d5cab49f31a26aa1)
  - [`(reals y | reals alpha, reals tau, reals beta, reals delta) : real`](positive_lower-bounded_distributions.qmd#index-entry-7c21d286a5cd6e11195df3046653f79a72c95e63)
 
 
 **wiener_lupdf**:
 
+ - [`(real y | real alpha, real tau, real beta, real delta, real var_delta) : real`](positive_lower-bounded_distributions.qmd#index-entry-27fbddb7c175dbc42b3a77639443abb89b1c93ba)
+ - [`(real y | real alpha, real tau, real beta, real delta, real var_delta, real var_beta, real var_tau) : real`](positive_lower-bounded_distributions.qmd#index-entry-330634d3f68975f72410dd323545f5801a409119)
  - [`(reals y | reals alpha, reals tau, reals beta, reals delta) : real`](positive_lower-bounded_distributions.qmd#index-entry-9511656e972acbc5b9054dabc90abaa4214250d3)
 
 
@@ -3893,7 +3897,7 @@ pagetitle: Alphabetical Index
 
 **zeros_row_vector**:
 
- - [`(int n) : vector`](matrix_operations.qmd#index-entry-4a264e38cea89262c5e2f6393b6c9988eef3e937)
  - [`(int n) : row_vector`](matrix_operations.qmd#index-entry-7b23944569e7b31c1e4f17cc78de7996783733f1)
+ - [`(int n) : vector`](matrix_operations.qmd#index-entry-4a264e38cea89262c5e2f6393b6c9988eef3e937)
 
 

--- a/src/functions-reference/positive_lower-bounded_distributions.qmd
+++ b/src/functions-reference/positive_lower-bounded_distributions.qmd
@@ -159,29 +159,44 @@ For a description of argument and return types, see section
 
 ### Probability density function
 
-If $\alpha \in \mathbb{R}^+$, $\tau \in \mathbb{R}^+$, $\beta \in [0, 1]$,
+If $\alpha \in \mathbb{R}^+$, $\tau \in \mathbb{R}^+$, $\beta \in (0, 1)$,
 $\delta \in \mathbb{R}$, $s_{\delta} \in \mathbb{R}^{\geq 0}$, $s_{\beta} \in [0, 1)$, and
 $s_{\tau} \in \mathbb{R}^{\geq 0}$ then for $y > \tau$,
 
-\begin{eqnarray*}
-\text{Wiener}(y|\alpha, \tau, \beta, \delta, s_{\delta}, s_{\beta}, s_{\tau})
 
-&=& \frac{1}{s_{\tau}}
-\int_{\tau}^{\tau + s_{\tau}} \frac{1}{s_{\beta}}\int_{\beta -0.5s_{\beta}}^{\beta + 0.5s_{\beta}}
-M \times p_3(y-\tau|a,\delta,\omega) \ d\omega \ d\tau,
-\end{eqnarray*}
-where $M$ and $p_3()$ are defined, by using $t:=y-\tau$, as
- \begin{eqnarray*}
- M := \frac{1}{\sqrt{1+s^2_{\delta} t}}
- \mathbb{e}^{a\delta\omega+\frac{\delta^2t}{2}+\frac{s^2_{\delta} a^2
- \omega^2-2a\delta\omega-\delta^2t}{2(1+s^2_{\delta}t)}} \text{ and} \\ p_3(t|a,\delta,\beta) :=
- \frac{1}{a^2} \mathbb{e}^{-a \delta \beta -\frac{\delta^2t}{2}} f(\frac{t}{a^2}|0,1,\beta), \end{eqnarray*}
- where  $f(t^*=\frac{t}{a^2}|0,1,\beta)$ has two forms
- \begin{eqnarray*}
- f_l(t^*|0,1,\beta) = \sum_{k=1}^{\infty} k\pi \mathbb{e}^{-\frac{k^2\pi^2t^*}{2}}
- \sin{(k \pi \beta)}\text{ and} \\
- f_s(t^*|0,1,\beta) = \sum_{k=-\infty}^{\infty} \frac{1}{\sqrt{2\pi (t^*)^3}}
- (\beta+2k) \mathbb{e}^{-\frac{(\beta+2k)^2}{2t^*}}, \end{eqnarray*}
+\begin{equation*}
+\begin{split}
+&\text{Wiener}(y\mid \alpha,\tau,\beta,\delta,s_{\delta},s_{\beta},s_{\tau}) =
+\\
+&\frac{1}{s_{\tau}}\int_{\tau}^{\tau+s_{\tau}}\frac{1}{s_{\beta}}\int_{\beta-\frac{1}{2}s_{\beta}}^{\beta+\frac{1}{2}s_{\beta}}\int_{-\infty}^{\infty} p_3(y-{\tau_0}\mid \alpha,\nu,\omega)
+\\
+&\times \frac{1}{\sqrt{2\pi s_{\delta}^2}}\exp\Bigl(-\frac{(\nu-\delta)^2}{2s_{\delta}^2}\Bigr) \,d\nu \,d\omega \,d{\tau_0}=
+\\
+&\frac{1}{s_{\tau}}\int_{\tau}^{\tau+s_{\tau}}\frac{1}{s_{\beta}}\int_{\beta-\frac{1}{2}s_{\beta}}^{\beta+\frac{1}{2}s_{\beta}} M\times p_3(y-{\tau_0}\mid \alpha,\nu,\omega) \,d\omega \,d{\tau_0},
+\end{split}
+\end{equation*}
+
+where $p()$ denotes the density function, and $M$ and $p_3()$ are defined, by using $t:=y-{\tau_0}$, as
+
+\begin{equation*}
+M \coloneqq \frac{1}{\sqrt{1+s_{\delta}^2t}}\exp\Bigl(\alpha{\delta}\omega+\frac{\delta^2t}{2}+\frac{s_{\delta}^2\alpha^2\omega^2-2\alpha{\delta}\omega-\delta^2t}{2(1+s_{\delta}^2t)}\Bigr)\text{ and}
+\end{equation*}
+
+\begin{equation*}
+p_3(t\mid \alpha,\delta,\beta) \coloneqq \frac{1}{\alpha^2}\exp\Bigl(-\alpha\delta\beta-\frac{\delta^2t}{2}\Bigr)f(\frac{t}{\alpha^2}\mid 0,1,\beta),
+\end{equation*}
+
+where $f(t^*=\frac{t}{\alpha^2}\mid0,1,\beta)$ can be specified in two ways:
+
+\begin{equation*}
+f_l(t^*\mid 0,1,\beta) = \sum_{k=1}^\infty k\pi \exp\Bigl(-\frac{k^2\pi^2t^*}{2}\Bigr)\sin(k\pi \beta)\text{ and}
+\end{equation*}
+
+\begin{equation*}
+f_s(t^*\mid0,1,\beta) = \sum_{k=-\infty}^\infty \frac{1}{\sqrt{2\pi(t^*)^3}}(\beta+2k) \exp\Bigl(-\frac{(\beta+2k)^2}{2t^*}\Bigr).
+\end{equation*}
+
+Which of these is used in the computations depends on which expression requires the smaller number of components $k$ to guarantee a pre-specified precision
 
 In the case where $s_{\delta}$, $s_{\beta}$, and $s_{\tau}$ are all $0$, this simplifies to
 \begin{equation*}

--- a/src/functions-reference/positive_lower-bounded_distributions.qmd
+++ b/src/functions-reference/positive_lower-bounded_distributions.qmd
@@ -159,8 +159,32 @@ For a description of argument and return types, see section
 
 ### Probability density function
 
-If $\alpha \in \mathbb{R}^+$, $\tau \in \mathbb{R}^+$, $\beta \in [0,
-1]$ and $\delta \in \mathbb{R}$, then for $y > \tau$, \begin{equation*}
+If $\alpha \in \mathbb{R}^+$, $\tau \in \mathbb{R}^+$, $\beta \in [0, 1]$,
+$\delta \in \mathbb{R}$, $s_{\delta} \in \mathbb{R}^{\geq 0}$, $s_{\beta} \in [0, 1)$, and
+$s_{\tau} \in \mathbb{R}^{\geq 0}$ then for $y > \tau$,
+
+\begin{eqnarray*}
+\text{Wiener}(y|\alpha, \tau, \beta, \delta, s_{\delta}, s_{\beta}, s_{\tau})
+
+&=& \frac{1}{s_{\tau}}
+\int_{\tau}^{\tau + s_{\tau}} \frac{1}{s_{\beta}}\int_{\beta -0.5s_{\beta}}^{\beta + 0.5s_{\beta}}
+M \times p_3(y-\tau|a,\delta,\omega) \ d\omega \ d\tau,
+\end{eqnarray*}
+where $M$ and $p_3()$ are defined, by using $t:=y-\tau$, as
+ \begin{eqnarray*}
+ M := \frac{1}{\sqrt{1+s^2_{\delta} t}}
+ \mathbb{e}^{a\delta\omega+\frac{\delta^2t}{2}+\frac{s^2_{\delta} a^2
+ \omega^2-2a\delta\omega-\delta^2t}{2(1+s^2_{\delta}t)}} \text{ and} \\ p_3(t|a,\delta,\beta) :=
+ \frac{1}{a^2} \mathbb{e}^{-a \delta \beta -\frac{\delta^2t}{2}} f(\frac{t}{a^2}|0,1,\beta), \end{eqnarray*}
+ where  $f(t^*=\frac{t}{a^2}|0,1,\beta)$ has two forms
+ \begin{eqnarray*}
+ f_l(t^*|0,1,\beta) = \sum_{k=1}^{\infty} k\pi \mathbb{e}^{-\frac{k^2\pi^2t^*}{2}}
+ \sin{(k \pi \beta)}\text{ and} \\
+ f_s(t^*|0,1,\beta) = \sum_{k=-\infty}^{\infty} \frac{1}{\sqrt{2\pi (t^*)^3}}
+ (\beta+2k) \mathbb{e}^{-\frac{(\beta+2k)^2}{2t^*}}, \end{eqnarray*}
+
+In the case where $s_{\delta}$, $s_{\beta}$, and $s_{\tau}$ are all $0$, this simplifies to
+\begin{equation*}
 \text{Wiener}(y|\alpha, \tau, \beta, \delta) =
 \frac{\alpha^3}{(y-\tau)^{3/2}} \exp \! \left(- \delta \alpha \beta -
 \frac{\delta^2(y-\tau)}{2}\right) \sum_{k = - \infty}^{\infty} (2k +

--- a/src/functions-reference/positive_lower-bounded_distributions.qmd
+++ b/src/functions-reference/positive_lower-bounded_distributions.qmd
@@ -174,6 +174,15 @@ If $\alpha \in \mathbb{R}^+$, $\tau \in \mathbb{R}^+$, $\beta \in [0,
 
 Increment target log probability density with `wiener_lupdf(y | alpha, tau, beta, delta)`.
 {{< since 2.7 >}}
+
+`y ~ ` **`wiener`**`(alpha, tau, beta, delta, var_delta)`
+Increment target log probability density with `wiener_lupdf(y | alpha, tau, beta, delta, var_delta)`.
+{{< since 2.35 >}}
+
+`y ~ ` **`wiener`**`(alpha, tau, beta, delta, var_delta, var_beta, var_tau)`
+Increment target log probability density with `wiener_lupdf(y | alpha, tau, beta, delta, var_delta, var_beta, var_tau)`.
+{{< since 2.35 >}}
+
 <!-- real; wiener ~; -->
 \index{{\tt \bfseries wiener }!sampling statement|hyperpage}
 
@@ -183,19 +192,70 @@ Increment target log probability density with `wiener_lupdf(y | alpha, tau, beta
 \index{{\tt \bfseries wiener\_lpdf }!{\tt (reals y \textbar\ reals alpha, reals tau, reals beta, reals delta): real}|hyperpage}
 
 `real` **`wiener_lpdf`**`(reals y | reals alpha, reals tau, reals beta, reals delta)`<br>\newline
-The log of the Wiener first passage time density of y given boundary
-separation alpha, non-decision time tau, a-priori bias beta and drift
-rate delta
+The log of the Wiener first passage time density of `y` given boundary
+separation `alpha`, non-decision time `tau`, a-priori bias `beta`, and drift
+rate `delta`.
 {{< since 2.18 >}}
+
+<!-- real; wiener_lpdf; (real y | real alpha, real tau, real beta, real delta, real var_delta); -->
+\index{{\tt \bfseries wiener\_lpdf }!{\tt (real y \textbar\ real alpha, real tau, real beta, real delta, real var\_delta): real}|hyperpage}
+
+`real` **`wiener_lpdf`**`(real y | real alpha, real tau, real beta, real delta, real var_delta)`<br>\newline
+The log of the Wiener first passage time density of `y` given boundary
+separation `alpha`, non-decision time `tau`, a-priori bias `beta`, drift
+rate `delta`, and inter-trial drift rate variability `var_delta`.
+
+Setting `var_delta` to `0` recovers the 4-parameter signature above.
+{{< since 2.35 >}}
+
+<!-- real; wiener_lpdf; (real y | real alpha, real tau, real beta, real delta, real var_delta, real var_beta, real var_tau); -->
+\index{{\tt \bfseries wiener\_lpdf }!{\tt (real y \textbar\ real alpha, real tau, real beta, real delta, real var\_delta, real var\_beta, real var\_tau): real}|hyperpage}
+
+`real` **`wiener_lpdf`**`(real y | real alpha, real tau, real beta, real delta, real var_delta, real var_beta, real var_tau)`<br>\newline
+The log of the Wiener first passage time density of `y` given boundary
+separation `alpha`, non-decision time `tau`, a-priori bias `beta`, drift
+rate `delta`, inter-trial drift rate variability `var_delta`, inter-trial
+variability of the starting point (bias) `var_beta`, and inter-trial variability
+of the non-decision time `var_tau`.
+
+Setting `var_delta`, `var_beta`, and `var_tau` to `0` recovers the 4-parameter signature above.
+{{< since 2.35 >}}
 
 <!-- real; wiener_lupdf; (reals y | reals alpha, reals tau, reals beta, reals delta); -->
 \index{{\tt \bfseries wiener\_lupdf }!{\tt (reals y \textbar\ reals alpha, reals tau, reals beta, reals delta): real}|hyperpage}
 
 `real` **`wiener_lupdf`**`(reals y | reals alpha, reals tau, reals beta, reals delta)`<br>\newline
-The log of the Wiener first passage time density of y given boundary
-separation alpha, non-decision time tau, a-priori bias beta and drift
-rate delta dropping constant additive terms
+The log of the Wiener first passage time density of `y` given boundary
+separation `alpha`, non-decision time `tau`, a-priori bias `beta`, and drift
+rate `delta`, dropping constant additive terms
 {{< since 2.25 >}}
+
+
+<!-- real; wiener_lupdf; (real y | real alpha, real tau, real beta, real delta, real var_delta); -->
+\index{{\tt \bfseries wiener\_lupdf }!{\tt (real y \textbar\ real alpha, real tau, real beta, real delta, real var\_delta): real}|hyperpage}
+
+`real` **`wiener_lupdf`**`(real y | real alpha, real tau, real beta, real delta, real var_delta)`<br>\newline
+The log of the Wiener first passage time density of `y` given boundary
+separation `alpha`, non-decision time `tau`, a-priori bias `beta`, drift
+rate `delta`, and inter-trial drift rate variability `var_delta`,
+dropping constant additive terms.
+
+Setting `var_delta` to `0` recovers the 4-parameter signature above.
+{{< since 2.35 >}}
+
+<!-- real; wiener_lupdf; (real y | real alpha, real tau, real beta, real delta, real var_delta, real var_beta, real var_tau); -->
+\index{{\tt \bfseries wiener\_lupdf }!{\tt (real y \textbar\ real alpha, real tau, real beta, real delta, real var\_delta, real var\_beta, real var\_tau): real}|hyperpage}
+
+`real` **`wiener_lupdf`**`(real y | real alpha, real tau, real beta, real delta, real var_delta, real var_beta, real var_tau)`<br>\newline
+The log of the Wiener first passage time density of `y` given boundary
+separation `alpha`, non-decision time `tau`, a-priori bias `beta`, drift
+rate `delta`, inter-trial drift rate variability `var_delta`, inter-trial
+variability of the starting point (bias) `var_beta`, and inter-trial variability
+of the non-decision time `var_tau`, dropping constant additive terms.
+
+Setting `var_delta`, `var_beta`, and `var_tau` to `0` recovers the 4-parameter signature above.
+{{< since 2.35 >}}
+
 
 ### Boundaries
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

This closes #779 and adds documentation for the functions added in https://github.com/stan-dev/math/pull/2822.

The signatures are fairly straightforward. The preamble which gives the definition of the distribution I adapted from the doxygen comment @Franzi2114 has in [the Math documentation](https://mc-stan.org/math/group__prob__dists_gaccf7f4ee90a8bcf19574f2668fe1c546.html#gaccf7f4ee90a8bcf19574f2668fe1c546). I would appreciate if she could look it over, because I made a few changes (mostly for variable name consistency), and because the original uses $t_0$, $\tau_0$, and $t_o$ as variable names, which I _think_ are all what the existing documentation called $\tau$?

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
