### PR TITLE
Improve docs with respect to statistical terminology

### DIFF
--- a/src/stan-users-guide/cross-validation.qmd
+++ b/src/stan-users-guide/cross-validation.qmd
@@ -190,7 +190,7 @@ of $\tilde{y}$ given the predictors and training data,
 \\[4pt]
 & \approx & \frac{1}{M} \sum_{m = 1}^M \tilde{y}_n^{(m)}
 \end{eqnarray*}
-where $\tilde{y}_n^{(m)}$ is drawn from the sampling distribution
+where $\tilde{y}_n^{(m)}$ is drawn from the data model
 $$
 \tilde{y}_n^{(m)}
 \sim p(\tilde{y}_n \mid \tilde{x}_n, \alpha^{(m)}, \beta^{(m)}),
@@ -213,7 +213,7 @@ the same result is obtained by averaging linear predictions,
 \\[4pt]
 & \approx &
 \frac{1}{M} \sum_{m = 1}^M
-  \alpha^{(m)} + \beta^{(m)} \cdot \tilde{x}_n
+  \alpha^{(m)} + \beta^{(m)} \cdot \tilde{x}_n.
 \end{eqnarray*}
 This is possible because
 $$

--- a/src/stan-users-guide/efficiency-tuning.qmd
+++ b/src/stan-users-guide/efficiency-tuning.qmd
@@ -1379,7 +1379,7 @@ Then the sum can be replaced with `a_b[ii[n], jj[n]]`.
 ## Exploiting conjugacy
 
 Continuing the model from the previous section, the conjugacy of the
-beta prior and binomial sampling distribution allow the model to be
+beta prior and binomial distribution allow the model to be
 further optimized to the following equivalent form.
 
 ```stan

--- a/src/stan-users-guide/finite-mixtures.qmd
+++ b/src/stan-users-guide/finite-mixtures.qmd
@@ -364,9 +364,9 @@ posterior inferences which do not refer to specific component labels
 are invariant under label switching and may be used directly.  This
 subsection considers a pair of examples.
 
-#### Predictive likelihood {-}
+#### Posterior predictive distribution {-}
 
-Predictive likelihood for a new observation $\tilde{y}$ given the
+Posterior predictive distribution for a new observation $\tilde{y}$ given the
 complete parameter vector $\theta$ will be
 $$
 p(\tilde{y} \mid y)
@@ -378,7 +378,7 @@ p(\tilde{y} \mid \theta)
 $$
 
 The normal mixture example from the previous section, with $\theta =
-(\mu, \sigma, \lambda)$, shows that the likelihood returns the same
+(\mu, \sigma, \lambda)$, shows that the model returns the same
 density under label switching and thus the predictive inference is
 sound.  In Stan, that predictive inference can be done either by
 computing $p(\tilde{y} \mid y)$, which is more efficient
@@ -435,9 +435,9 @@ $$
 As with other event probabilities, this can be calculated in the
 generated quantities block either by sampling $z_i$ and $z_j$ and
 using the indicator function on their equality, or by computing the
-term inside the integral as a generated quantity.  As with predictive
-likelihood, working in expectation is more statistically efficient than
-sampling.
+term inside the integral as a generated quantity.  As with posterior 
+predictive distribute, working in expectation is more statistically
+efficient than sampling.
 
 ## Zero-inflated and hurdle models {#zero-inflated.section}
 
@@ -468,13 +468,14 @@ of observing a count with a $\textsf{Poisson}(\lambda)$ distribution
 used for mixing proportions because $\lambda$ is the traditional
 notation for a Poisson mean parameter). Given the probability $\theta$
 and the intensity $\lambda$, the distribution for $y_n$ can be written as
-$$
-y_n \sim
+\begin{align*}
+y_n & = 0 \quad\text{with probability } \theta, \text{ and}\\
+y_n & \sim \textsf{Poisson}(y_n \mid \lambda) \quad\text{with probability } 1-\theta.
 \begin{cases}
- 0 & \quad\text{with probability } \theta, \text{ and}\\
- \textsf{Poisson}(y_n \mid \lambda) & \quad\text{with probability } 1-\theta.
-\end{cases}
-$$
+ 
+ 
+\end{align*}
+
 
 Stan does not support conditional distribution statements (with `~`) conditional on some parameter, and we need to consider the corresponding likelihood
 $$
@@ -578,10 +579,9 @@ flexible in that the zero outcomes can be deflated as well as
 inflated. Given the probability $\theta$ and the intensity $\lambda$,
 the distribution for $y_n$ can be written as
 $$
-y_n \sim
-\begin{cases}
- 0 & \quad\text{with probability } \theta, \text{and }\\
- \textsf{Poisson}_{x\neq 0}(y_n \mid \lambda) & \quad\text{with probability } 1-\theta,
+\begin{align*}
+y_n & = 0 \quad\text{with probability } \theta, \text{ and}\\
+y_n & \sim \textsf{Poisson}_{x\neq 0}(y_n \mid \lambda) \quad\text{with probability } 1-\theta,
 \end{cases}
 $$
 Where $\textsf{Poisson}_{x\neq 0}$ is a truncated Poisson distribution, truncated at $0$.

--- a/src/stan-users-guide/gaussian-processes.qmd
+++ b/src/stan-users-guide/gaussian-processes.qmd
@@ -27,9 +27,9 @@ covariance of the outputs corresponding to those input points in the
 functions drawn from the process.
 
 Gaussian processes can be encoded in Stan by implementing their mean and
-covariance functions and plugging the result into the Gaussian form of their
-sampling distribution, or by using the specialized covariance functions
-outlined below.  This form of model is straightforward and may be used for
+covariance functions or by using the specialized covariance functions
+outlined below, and plugging the result into the Gaussian model.  
+This form of model is straightforward and may be used for
 simulation, model fitting, or posterior predictive inference. A more efficient
 Stan implementation for the GP with a normally distributed outcome marginalizes
 over the latent Gaussian process, and applies a Cholesky-factor
@@ -360,7 +360,7 @@ constrained to be non-negative.  The computation of the covariance matrix
 `K` is now in the model block because it involves unknown parameters and
 thus can't simply be precomputed as transformed data.  The rest of the model
 consists of the priors for the hyperparameters and the multivariate
-Cholesky-parameterized normal likelihood, only now the value `y` is known
+Cholesky-parameterized normal distribution, only now the value `y` is known
 and the covariance matrix `K` is an unknown dependent on the
 hyperparameters, allowing us to learn the hyperparameters.
 
@@ -431,10 +431,10 @@ a new parameter vector of length $N$ called `eta`. This is used in the model
 block to generate a multivariate normal vector called $f$, corresponding to the
 latent GP. We put a $\textsf{normal}(0,1)$ prior on `eta` like we did in the
 Cholesky-parameterized GP in the simulation section.  The second difference is
-that our likelihood is now univariate, though we could code $N$ likelihood
-terms as one $N$-dimensional multivariate normal with an identity covariance
-matrix multiplied by $\sigma^2$. However, it is more efficient to use the
-vectorized statement as shown above.
+that although we could code the distribution statement for $y$ with
+one $N$-dimensional multivariate normal with an identity covariance
+matrix multiplied by $\sigma^2$, we instead use vectorized univariate
+normal distribution, which is equivalent but more efficient to use.
 
 ### Discrete outcomes with Gaussian processes {-}
 
@@ -445,7 +445,8 @@ discrete data models.
 #### Poisson GP {-}
 
 If we want to model count data, we can remove the $\sigma$ parameter, and use
-`poisson_log`, which implements a log link, for our likelihood rather
+`poisson_log`, which implements a Poisson distribution with log link function,
+rather
 than `normal`. We can also add an overall mean parameter, $a$, which
 will account for the marginal expected value for $y$. We do this because we
 cannot center count data like we would for normally distributed data.

--- a/src/stan-users-guide/measurement-error.qmd
+++ b/src/stan-users-guide/measurement-error.qmd
@@ -126,12 +126,12 @@ Exercise 3.5(b) by @GelmanEtAl:2013 provides an example.
 
 
 Letting $z_n$ be the unrounded measurement for $y_n$, the problem
-as stated assumes the likelihood
+as stated assumes
 $$
 z_n \sim \textsf{normal}(\mu, \sigma).
 $$
 
-The rounding process entails that $z_n \in (y_n - 0.5, y_n + 0.5)$.
+The rounding process entails that $z_n \in (y_n - 0.5, y_n + 0.5)$^{There are several different rounding rules (see, e.g., [Wikipedia: Rounding](https://en.wikipedia.org/wiki/Rounding)), which affect which interval ends are open and which are closed, but these do not matter here as for continuous $z_n$ $p(z_n=y_n-0.5)=p(z_n=y_n+0.5)=0$.}.
 The probability mass function for the discrete observation $y$ is then given
 by marginalizing out the unrounded measurement, producing the likelihood
 \begin{align*}
@@ -141,17 +141,17 @@ p(y_n \mid \mu, \sigma)
    -\Phi\!\left(\frac{y_n - 0.5 - \mu}{\sigma}\right).
 \end{align*}
 Gelman's answer for this problem took the noninformative prior to be
-uniform in the variance $\sigma^2$ on the log scale, which yields (due
-to the Jacobian adjustment), the prior density
+uniform in the variance $\sigma^2$ on the log scale, but we replace it
+with more recently recommended half-normal prior on $\sigma$
 $$
-p(\mu, \sigma^2) \propto \frac{1}{\sigma^2}.
+\sigma \sim \textsf{normal}^+(0, 1).
 $$
 The posterior after observing $y = (10, 10, 12, 11, 9)$ can be
 calculated by Bayes's rule as
 \begin{align*}
-p(\mu, \sigma^2 \mid y)
- &\propto p(\mu, \sigma^2) \ p(y \mid \mu, \sigma^2) \\
- &\propto \frac{1}{\sigma^2} \ \prod_{n=1}^5
+p(\mu, \sigma \mid y)
+ &\propto p(\mu, \sigma) \ p(y \mid \mu, \sigma) \\
+ &\propto \textsf{normal}^+(\sigma \mid 0, 1)\prod_{n=1}^5
   \left( \Phi\!\left(\frac{y_n + 0.5 - \mu}{\sigma}\right)
         -\Phi\!\left(\frac{y_n - 0.5 - \mu}{\sigma}\right)
   \right).
@@ -168,28 +168,24 @@ data {
 }
 parameters {
   real mu;
-  real<lower=0> sigma_sq;
-}
-transformed parameters {
   real<lower=0> sigma;
-  sigma = sqrt(sigma_sq);
 }
 model {
-  target += -2 * log(sigma);
+  sigma ~ normal(0, 1);
   for (n in 1:N) {
-    target += log(Phi((y[n] + 0.5 - mu) / sigma)
-                  - Phi((y[n] - 0.5 - mu) / sigma));
+    target += log_diff_exp(normal_lcdf(y[n] + 0.5 | mu, sigma),
+                           normal_lcdf(y[n] - 0.5 | mu, sigma));
   }
 }
 ```
+where `normal_lcdf(y[n]+0.5 | mu, sigma)` is equal to `log(Phi((y[n] +
+0.5 - mu) / sigma))`, and `log_diff_exp(a, b)` computes `log(exp(a) -
+exp(b))` in numerically more stable way.
 
 Alternatively, the model may be defined with latent parameters for the
-unrounded measurements $z_n$.  The Stan code in this case uses the
-likelihood for $z_n$ directly while respecting the constraint $z_n \in
-(y_n - 0.5, y_n + 0.5)$.  Because Stan does not allow varying upper-
-and lower-bound constraints on the elements of a vector (or array),
-the parameters are declared to be the rounding error $y - z$, and
-then $z$ is defined as a transformed parameter.
+unrounded measurements $z_n$.  The Stan code in this case uses a
+distribution statement for $z_n$ directly while respecting the 
+constraint $z_n \in (y_n - 0.5, y_n + 0.5)$.
 
 ```stan
 data {
@@ -198,17 +194,11 @@ data {
 }
 parameters {
   real mu;
-  real<lower=0> sigma_sq;
-  vector<lower=-0.5, upper=0.5>[N] y_err;
-}
-transformed parameters {
   real<lower=0> sigma;
-  vector[N] z;
-  sigma = sqrt(sigma_sq);
-  z = y + y_err;
+  vector<lower=y-0.5, upper=y+0.5>[N] z;
 }
 model {
-  target += -2 * log(sigma);
+  sigma ~ normal(0, 1);
   z ~ normal(mu, sigma);
 }
 ```

--- a/src/stan-users-guide/multi-indexing.qmd
+++ b/src/stan-users-guide/multi-indexing.qmd
@@ -11,7 +11,7 @@ array of integer indexes or range bounds.  In many cases, there are
 functions that provide similar behavior.
 
 Allowing multiple indexes supports inline vectorization of models.
-For instance, consider the likelihood for a varying-slope,
+For instance, consider the data model for a varying-slope,
 varying-intercept hierarchical linear regression, which could be coded
 as
 

--- a/src/stan-users-guide/parallelization.qmd
+++ b/src/stan-users-guide/parallelization.qmd
@@ -514,7 +514,7 @@ Each of the fifty states $k \in \{1,\dotsc,50\}$ will have its own slope
 $\beta_k$ and intercept $\alpha_k$ to model the log odds of voting for
 the Republican candidate as a function of income.  Suppose there are
 $N$ voters and with voter $n \in 1{:}N$ being in state $s[n]$ with
-income $x_n$.  The likelihood for the vote $y_n \in \{ 0, 1 \}$ is
+income $x_n$.  The data model for the vote $y_n \in \{ 0, 1 \}$ is
 $$
 y_n \sim \textsf{Bernoulli}
 \Big(
@@ -556,16 +556,16 @@ model {
 ```
 
 For this model the vector of predictors `x` is coded as a vector,
-corresponding to how it is used in the likelihood.
+corresponding to how it is used in the model.
 The priors for `mu` and `sigma` are vectorized.  The priors
 on the two components of `beta` (intercept and slope,
 respectively) are stored in a $K \times 2$ matrix.
 
-The likelihood is also
+The distribution statement is also
 vectorized using multi-indexing with index `kk` for the states
 and elementwise multiplication (`.*`) for the income `x`.
-The vectorized likelihood works out to the same thing as the following
-less efficient looped form.
+The vectorized distribution statement works out to the same thing 
+as the following less efficient looped form.
 
 ```stan
 for (n in 1:N) {
@@ -579,11 +579,13 @@ The mapped version of the model will map over the states `K`.
 This means the group-level parameters, real data, and integer-data
 must be arrays of the same size.
 
-The mapped implementation requires a function to be mapped.  The
+The mapped implementation requires a function to be mapped.  In this
+function we can't use distribution statements, but need to accumulate
+the desired log prior and log likelihood terms to the return value. The
 following function evaluates both the likelihood for the data observed
 for a group as well as the prior for the group-specific parameters
-(the name `bl_glm` derives from the fact that it's a generalized
-linear model with a Bernoulli likelihood and logistic link function).
+(the name `bernoulli_logit_glm` derives from the fact that it's a generalized
+linear model with a Bernoulli data model and logistic link function).
 
 ```stan
 functions {
@@ -669,7 +671,8 @@ model {
 The model as written here computes the priors for each group's
 parameters along with the likelihood contribution for the group.  An
 alternative mapping would leave the prior in the model block and only
-map the likelihood.  In a serial setting this shouldn't make much of a
+map the likelihood computation.  In a serial setting this shouldn't 
+make much of a
 difference, but with parallelization, there is reduced communication
 (the prior's parameters need not be transmitted) and also reduced
 parallelization with the version that leaves the prior in the model

--- a/src/stan-users-guide/posterior-prediction.qmd
+++ b/src/stan-users-guide/posterior-prediction.qmd
@@ -84,13 +84,13 @@ $$
 \tilde{y}^{(m)} \sim p(y \mid \theta^{(m)}).
 $$
 
-Randomly drawing $\tilde{y}$ from the sampling distribution is
+Randomly drawing $\tilde{y}$ from the data model is
 critical because there are two forms of uncertainty in posterior
-predictive quantities, sampling uncertainty and estimation
-uncertainty.  Estimation uncertainty arises because $\theta$ is being
-estimated based only on a sample of data $y$. Sampling uncertainty
-arises because even a known value of $\theta$ leads to a sampling
-distribution $p(\tilde{y} \mid \theta)$ with variation in $\tilde{y}$.
+predictive quantities, aleatoric uncertainty and epistemic
+uncertainty.  Epistemic uncertainty arises because $\theta$ is unknown
+and estimated based only on a finite sample of data $y$. Aleatoric uncertainty
+arises because even a known value of $\theta$ leads to uncertainty about
+new $\tilde{y}$ as described by the data model $p(\tilde{y} \mid \theta)$.
 Both forms of uncertainty show up in the factored form of the
 posterior predictive distribution,
 $$
@@ -98,11 +98,11 @@ p(\tilde{y} \mid y)
 =
 \int
 \underbrace{p(\tilde{y} \mid \theta)}_{\begin{array}{l}
-                                         \textrm{sampling}
+                                         \textrm{aleatoric}
                                          \\[-2pt] \textrm{uncertainty}
                                        \end{array}}
 \cdot \underbrace{p(\theta \mid y)}_{\begin{array}{l}
-                                         \textrm{estimation}
+                                         \textrm{epistemic}
                                          \\[-2pt] \textrm{uncertainty}
                                        \end{array}}
 \, \textrm{d}\theta.
@@ -117,12 +117,12 @@ using the generated quantities block.
 ### Simple Poisson model {-}
 
 For example, consider a simple Poisson model for count data with a
-rate parameter $\lambda > 0$ following a gamma-distributed prior,
+rate parameter $\lambda > 0$ having a gamma-distributed prior,
 $$
 \lambda \sim \textrm{gamma}(1, 1).
 $$
-The likelihood for $N$ observations $y_1, \ldots, y_N$ is modeled as
-Poisson,
+The $N$ observations $y_1, \ldots, y_N$ are modeled as
+Poisson distributed,
 $$
 y_n \sim \textrm{poisson}(\lambda).
 $$
@@ -148,10 +148,10 @@ generated quantities {
   int<lower=0> y_tilde = poisson_rng(lambda);
 }
 ```
-The random draw from the sampling distribution for $\tilde{y}$ is
+The random draw from the data model for $\tilde{y}$ is
 coded using Stan's Poisson random number generator in the generated
-quantities block.  This accounts for the sampling component of the
-uncertainty; Stan's posterior sampler will account for the estimation
+quantities block.  This accounts for the aleatoric component of the
+uncertainty; Stan's posterior sampler will account for the epistemic
 uncertainty, generating a new $\tilde{y}^{(m)} \sim p(y \mid
 \lambda^{(m)})$ for each posterior draw $\lambda^{(m)} \sim p(\theta
 \mid y).$
@@ -262,14 +262,14 @@ The result from running Stan is a predictive sample $\tilde{y}^{(1)},
 The mean of the posterior predictive distribution is the expected value
 \begin{align}
 \mathbb{E}[\tilde{y} \mid \tilde{x}, x, y]
-& = &
+& = 
 \int
 \tilde{y}
 \cdot p(\tilde{y} \mid \tilde{x}, \theta)
 \cdot p(\theta \mid x, y)
 \, \textrm{d}\theta
 \\[4pt]
-& \approx & \frac{1}{M} \sum_{m = 1}^M \tilde{y}^{(m)},
+& \approx \frac{1}{M} \sum_{m = 1}^M \tilde{y}^{(m)},
 \end{align}
 where the $\tilde{y}^{(m)} \sim p(\tilde{y} \mid \tilde{x}, x, y)$ are
 drawn from the posterior predictive distribution.  Thus the posterior
@@ -372,7 +372,7 @@ Posterior predictive draws $\tilde{y}^{(m)} \sim p(\tilde{y} \mid
 $$
 \tilde{y}^{(m)} \sim p(y \mid \tilde{x}, \theta^{(m)})
 $$
-from the sampling distribution.  Note that drawing $\tilde{y}^{(m)}$
+from the data model.  Note that drawing $\tilde{y}^{(m)}$
 only depends on the new predictors $\tilde{x}$ and the posterior draws
 $\theta^{(m)}$.  Most importantly, neither the original data or the
 model density is required.

--- a/src/stan-users-guide/posterior-predictive-checks.qmd
+++ b/src/stan-users-guide/posterior-predictive-checks.qmd
@@ -287,7 +287,7 @@ according to the priors, then simulating data
 $$
 y^{\textrm{sim}} \sim p(y \mid \theta^{\textrm{sim}})
 $$
-according to the sampling distribution given the simulated
+according to the data model given the simulated
 parameters.  The result is a simulation from the joint
 distribution,
 $$
@@ -402,7 +402,7 @@ In this textbook example, the prior is univariate and directly related
 to the expected number of points scored, and could thus be directly
 inspected for consistency with prior knowledge about scoring rates in
 football.  There will not be the same kind of direct connection when
-the prior and sampling distributions are multivariate.  In these more
+the prior and data model distributions are multivariate.  In these more
 challenging situations, prior predictive checks are an easy way to get
 a handle on the implications of a prior in terms of what it says the
 data is going to look like;  for a more complex application involving
@@ -424,7 +424,7 @@ purely posterior predictive check, but falls somewhere in between.
 For example, consider a simple varying intercept logistic regression,
 with intercepts $\alpha_k$ for $k \in 1:K$.  Each data item
 $y_n \in \{ 0, 1 \}$ is assumed to correspond to group $kk_n \in 1:K.$
-The sampling distribution is thus
+The data model is thus
 $$
 y_n \sim \textrm{bernoulli}(\textrm{logit}^{-1}(\alpha_{kk[n]})).
 $$
@@ -479,7 +479,7 @@ model {
   mu ~ normal(0, 2);               // hyperprior
   sigma ~ lognormal(0, 1);
   alpha ~ normal(mu, sigma);       // hierarchical prior
-  y ~ bernoulli_logit(alpha[kk]);  // sampling distribution
+  y ~ bernoulli_logit(alpha[kk]);  // data model
 }
 generated quantities {
   // alpha replicated;  mu and sigma not replicated
@@ -500,7 +500,7 @@ observed and replicated data.
 ### Posterior predictive model {-}
 
 For example, posterior predictive replication may be formulated
-using sampling notation as follows.
+using distribution notation as follows.
 \begin{eqnarray*}
 \theta & \sim & p(\theta)
 \\[2pt]
@@ -508,7 +508,7 @@ y & \sim & p(y \mid \theta)
 \\[2pt]
 y^{\textrm{rep}} & \sim & p(y \mid \theta)
 \end{eqnarray*}
-The heavily overloaded sampling notation is meant to indicate that
+The heavily overloaded distribution notation is meant to indicate that
 both $y$ and $y^{\textrm{rep}}$ are drawn from the same distribution,
 or more formally using capital letters to distinguish random
 variables, that the conditional densities $p_{Y^{\textrm{rep}} \mid
@@ -544,7 +544,7 @@ p(\theta, y^{\textrm{rep}}) = p(\theta) \cdot p(y^{\textrm{rep}} \mid
 $$
 
 It is typically straightforward to draw $\theta$ from the prior and
-$y^{\textrm{rep}}$ from the sampling distribution given $\theta$
+$y^{\textrm{rep}}$ from the data model given $\theta$
 efficiently.  In cases where it is not, the model may be coded and
 executed just as the posterior predictive model, only with no data.
 

--- a/src/stan-users-guide/poststratification.qmd
+++ b/src/stan-users-guide/poststratification.qmd
@@ -95,7 +95,7 @@ Considering the same polling data from the previous section in a
 Bayesian setting, the uncertainty in the estimation of subgroup
 support is pushed through predictive inference in order to get some
 idea of the uncertainty of estimated support.  Continuing the example
-of the previous section, the likelihood remains the same,
+of the previous section, the data model remains the same,
 $$
 y_n \sim \textrm{bernoulli}(\theta_{jj[n]}),
 $$
@@ -105,7 +105,7 @@ $\theta_j$ is the proportion of support in group $j$.
 This can be reformulated from a Bernoulli model to a binomial model in
 the usual way.  Letting $A_j$ be the number of respondents in group
 $j$ and $a_j$ be the number of positive responses in group $j$, the
-likelihood may be reduced to the form
+data model may be reduced to the form
 $$
 a_j \sim \textrm{binomial}(A_j, \theta_j).
 $$
@@ -156,7 +156,8 @@ generated quantities {t
   real<lower=0, upper=1> phi = dot(N, theta) / sum(N);
 }
 ```
-The likelihood is vectorized, and implicitly sums over the $j$.
+The binomial distribution statement is vectorized, and implicitly generates 
+the joint likelihood for the $J$ terms.
 The prior is implicitly uniform on $(0, 1),$ the support of $\theta.$
 The summation is computed using a dot product and the sum function,
 which is why `N` was declared as a vector rather than as an array of
@@ -238,7 +239,7 @@ pooling among the groups.  The only drawback is that if the number of
 groups is small, it can be hard to fit these models without strong
 hyperpriors.
 
-The model introduced in the previous section had likelihood
+The model introduced in the previous section had the data model
 $$
 y_n \sim
 \textrm{bernoulli}(\textrm{logit}^{-1}(
@@ -260,7 +261,7 @@ The other regression parameters can be given hierarchical priors,
 \\[2pt]
 \delta_{1:5} & \sim & \textrm{normal}(0, \sigma^{\delta})
 \\[2pt]
-\epsilon_{1:50} & \sim & \textrm{normal}(0, \sigma^{\epsilon})
+\epsilon_{1:50} & \sim & \textrm{normal}(0, \sigma^{\epsilon}).
 \end{eqnarray*}
 
 
@@ -440,7 +441,7 @@ collected into two parallel arrays indexed by group.
 array[G] int<lower=0> pos_votes;
 array[G] int<lower=0> total_votes;
 ```
-Finally, the likelihood is converted to binomial.
+Finally, the data model is converted to binomial.
 ```stan
 pos_votes ~ binomial_logit(total_votes,
                            alpha + beta[age] + ...);
@@ -467,7 +468,7 @@ In the log odds calculation, introduce a new term
 ```
 [epsilon, -epsilon][sex]';
 ```
-That is, the likelihood will now look like
+That is, the data model will now look like
 ```stan
   y ~ bernoulli_logit(alpha + beta[age] + gamma[income] + delta[state]
                       + [epsilon, -epsilon][sex]');
@@ -524,4 +525,4 @@ expect_pos
 	         + income[d] * psi);
 ```
 Here `d` is the loop variable looping over states.  This ensures that
-the poststratification formula matches the likelihood formula.
+the poststratification formula matches the model formula.

--- a/src/stan-users-guide/problematic-posteriors.qmd
+++ b/src/stan-users-guide/problematic-posteriors.qmd
@@ -30,7 +30,7 @@ redundant intercept parameters.^[This example was raised by Richard McElreath on
 
 Suppose there are observations $y_n$ for $n \in \{1,\dotsc,N\}$,
 two intercept parameters $\lambda_1$ and
-$\lambda_2$, a scale parameter $\sigma > 0$, and the sampling distribution
+$\lambda_2$, a scale parameter $\sigma > 0$, and the data model
 $$
 y_n \sim \textsf{normal}(\lambda_1 + \lambda_2, \sigma).
 $$
@@ -61,7 +61,7 @@ along the line where $\lambda_2 = \lambda_1 + c$ for some constant
 $c$.
 
 Contrast this model with a simple regression with a single intercept
-parameter $\mu$ and sampling distribution
+parameter $\mu$ and data model
 $$
 y_n \sim \textsf{normal}(\mu,\sigma).
 $$
@@ -97,7 +97,7 @@ regression with two intercepts discussed above.
 
 The general form of the collinearity problem arises when predictors
 for a regression are collinear.  For example, consider a linear
-regression sampling distribution
+regression data model
 $$
 y_n \sim \textsf{normal}(x_n \beta, \sigma)
 $$
@@ -124,7 +124,7 @@ nearly collinear.
 #### Multiplicative issues with discrimination in IRT {-}
 
 Consider adding a discrimination parameter $\delta_i$ for each
-question in an IRT model, with data sampling model
+question in an IRT model, with data model
 $$
 y_{i, j} \sim \textsf{Bernoulli}(\operatorname{logit}^{-1}(\delta_i(\alpha_j - \beta_i))).
 $$
@@ -313,7 +313,7 @@ finitely many posterior maxima.
 
 Consider a normal mixture model with two location parameters $\mu_1$
 and $\mu_2$, a shared scale $\sigma > 0$, a mixture ratio $\theta \in
-[0,1]$, and likelihood
+[0,1]$, and data model
 $$
 p(y \mid \theta,\mu_1,\mu_2,\sigma)
 = \prod_{n=1}^N \big( \theta \, \textsf{normal}(y_n \mid \mu_1,\sigma)
@@ -456,7 +456,7 @@ Another example of unbounded densities arises with a posterior such as
 $\textsf{beta}(\phi \mid 0.5,0.5)$, which can arise if seemingly weak beta
 priors are used for groups that have no data. This density is
 unbounded as $\phi \rightarrow 0$ and $\phi \rightarrow 1$. Similarly,
-a Bernoulli likelihood model coupled with a "weak" beta prior, leads
+a Bernoulli data model coupled with a "weak" beta prior, leads
 to a posterior
 \begin{align*}
 p(\phi \mid y)
@@ -509,7 +509,7 @@ modes.
 
 Consider a logistic regression model with $N$ observed outcomes $y_n
 \in \{ 0, 1 \}$, an $N \times K$ matrix $x$ of predictors, a
-$K$-dimensional coefficient vector $\beta$, and sampling distribution
+$K$-dimensional coefficient vector $\beta$, and data model
 $$
 y_n \sim \textsf{Bernoulli}(\operatorname{logit}^{-1}(x_n \beta)).
 $$
@@ -665,14 +665,14 @@ sigma            1.0  1.6e-03   0.071   9.3e-01   1.0   1.2   2094    27321    1
 ```
 
 On the top is the non-identified model with improper uniform priors
-and likelihood $y_n \sim \textsf{normal}(\lambda_1 + \lambda_2,
+and data model $y_n \sim \textsf{normal}(\lambda_1 + \lambda_2,
 \sigma)$.
 
-In the middle is the same likelihood as the middle plus priors
+In the middle is the same data model as in top plus priors
 $\lambda_k \sim \textsf{normal}(0,10)$.
 
 On the bottom is an identified model with an improper prior, with
-likelihood  $y_n \sim \textsf{normal}(\mu,\sigma)$.  All models
+data model  $y_n \sim \textsf{normal}(\mu,\sigma)$.  All models
 estimate $\mu$ at roughly 0.16 with low Monte Carlo standard
 error, but a high posterior standard deviation of 0.1;  the true
 value $\mu=0$ is within the 90% posterior intervals in all three models.

--- a/src/stan-users-guide/proportionality-constants.qmd
+++ b/src/stan-users-guide/proportionality-constants.qmd
@@ -14,27 +14,29 @@ need normalized to perform variational inference or do optimizations. The advant
 of working with unnormalized distributions is they can make computation quite a
 bit cheaper.
 
-There are three different syntaxes to work with distributions in Stan. The way
+There are three different syntaxes to build the model in Stan. The way
 to select between them is by determining if the proportionality constants are
-necessary. If performance is not a problem, it is always safe to use the normalized
-densities.
+necessary. If performance is not a problem, it is always safe to use the 
+normalized densities.
 
-The first two syntaxes use unnormalized densities (dropping proportionality
-constants):
+The distribution statement (`~`) and log density increment statement
+(`target +=`) with `_lupdf()` use unnormalized densities for $x$
+(dropping proportionality constants):
 
 ```stan
 x ~ normal(0, 1);
 target += normal_lupdf(x | 0, 1); // the 'u' is for unnormalized
 ```
 
-The final syntax uses the full normalized density (dropping no constants):
+The log density increment statement (`target +=`) with `_lpdf()`
+uses the full normalized density for $x$ (dropping no constants):
 
 ```stan
 target += normal_lpdf(x | 0, 1);
 ```
 
-For discrete distributions, the `target +=` syntax is `_lupmf` and `_lpmf`
-instead:
+For discrete distributions, the `target +=` syntax is using `_lupmf`
+and `_lpmf` instead:
 
 ```stan
 y ~ bernoulli(0.5);
@@ -55,7 +57,7 @@ approximated with variational inference), there is no need to compute it
 because it will not affect the results.
 
 Stan takes advantage of the proportionality constant fact with the `~` syntax.
-Take for instance the normal likelihood:
+Take for instance the normal data model:
 
 ```stan
 data {
@@ -94,7 +96,7 @@ statement here is:
 $$
 \textsf{normal\_lpdf}(x | \mu, \sigma) =
 -\log \left( \sigma \sqrt{2 \pi} \right)
--\frac{1}{2} \left( \frac{x - \mu}{\sigma} \right)^2
+-\frac{1}{2} \left( \frac{x - \mu}{\sigma} \right)^2.
 $$
 
 Now because the density here is only a function of $x$, the additive terms in
@@ -103,7 +105,7 @@ is enough to know only the quadratic term:
 
 $$
 \textsf{normal\_lupdf}(x | \mu, \sigma) =
--\frac{1}{2} \left( \frac{x - \mu}{\sigma} \right)^2
+-\frac{1}{2} \left( \frac{x - \mu}{\sigma} \right)^2.
 $$
 
 ## Keeping Proportionality Constants

--- a/src/stan-users-guide/regression.qmd
+++ b/src/stan-users-guide/regression.qmd
@@ -96,7 +96,7 @@ parameters {
   real<lower=0> sigma;  // error scale
 }
 model {
-  y ~ normal(x * beta + alpha, sigma);  // likelihood
+  y ~ normal(x * beta + alpha, sigma);  // data model
 }
 ```
 
@@ -191,7 +191,7 @@ parameters {
   real<lower=0> sigma;  // error scale
 }
 model {
-  y ~ normal(Q_ast * theta + alpha, sigma);  // likelihood
+  y ~ normal(Q_ast * theta + alpha, sigma);  // data model
 }
 generated quantities {
   vector[K] beta;
@@ -1207,11 +1207,11 @@ predictor.  To encode group membership, they assume individual $n$
 belongs to group $jj[n] \in \{ 1, \dotsc, J \}$.  Each individual $n$ also has an
 observed outcome $y_n$ taking on real values.
 
-#### Likelihood {-}
+#### Data model {-}
 
 The model is a linear regression with slope and intercept coefficients
 varying by group, so that $\beta_j$ is the coefficient $K$-vector for
-group $j$.  The likelihood function for individual $n$ is then just
+group $j$.  The data model for individual $n$ is then just
 $$
 y_n \sim \textsf{normal}(x_n \, \beta_{jj[n]}, \, \sigma)
 \quad\text{for}\quad n \in \{ 1, \dotsc, N \}.
@@ -1387,7 +1387,7 @@ functions, see the function reference manual.
 
 #### Optimization through vectorization {-}
 
-The code in the Stan program above can be sped up dramatically by replacing:
+The code in the Stan program above can be sped up dramatically by replacing the the distribution statement inside the for loop:
 
 ```stan
 for (n in 1:N) {
@@ -1395,7 +1395,7 @@ for (n in 1:N) {
 }
 ```
 
-with the vectorized form:
+with the vectorized distribution statement:
 
 ```stan
 {
@@ -1412,7 +1412,7 @@ variable `x_beta_jj`, which is then filled in a loop and used
 to define a vectorized distribution statement.  The reason this is such a
 big win is that it allows us to take the log of sigma only once and it
 greatly reduces the size of the resulting expression graph by packing
-all of the work into a single density function.
+all of the work into a single distribution function.
 
 Although it is tempting to redeclare `beta` and include a revised
 model block distribution statement,

--- a/src/stan-users-guide/simulation-based-calibration.qmd
+++ b/src/stan-users-guide/simulation-based-calibration.qmd
@@ -433,7 +433,7 @@ model.
 
 ![](./img/sbc-student-t-normal.png){width=90%}
 
-Simulation based calibration plots for location and scale of a normal model with standard normal prior on the location standard lognormal prior on the scale with mismatched generative model using a Student-t likelihood with 4 degrees of freedom.  The mean histogram appears uniform, but the scale parameter shows simulated values much smaller than fit values, clearly signaling the lack of calibration.
+Simulation based calibration plots for location and scale of a normal model with standard normal prior on the location standard lognormal prior on the scale with mismatched generative model using a Student-t data model with 4 degrees of freedom.  The mean histogram appears uniform, but the scale parameter shows simulated values much smaller than fit values, clearly signaling the lack of calibration.
 :::
 
 

--- a/src/stan-users-guide/survival.qmd
+++ b/src/stan-users-guide/survival.qmd
@@ -167,7 +167,7 @@ parameters {
 ```
 
 The exponential survival model and the prior are coded directly using
-vectorized sampling and ccdf statements.  This both simplifies the
+vectorized distribution and ccdf statements.  This both simplifies the
 code and makes it more computationally efficient by sharing
 computation across instances.
 
@@ -180,10 +180,10 @@ model {
 }
 ```
 
-The likelihood for observed failures is just the exponential
-distribution with rate `lambda`.  The Stan code is vectorized,
+The likelihood for rate `lambda` is just the density of exponential
+distribution for observed failure time.  The Stan code is vectorized,
 modeling each entry of the vector `t` as a having an exponential
-distribution with rate `lambda`. This likelihood could have been
+distribution with rate `lambda`. This data model could have been
 written as
 
 ```stan
@@ -192,10 +192,10 @@ for (n in 1:N) {
 }
 ```
 
-The log likelihood for censored items is the number of censored items
-times the log complementary cumulative distribution function (lccdf) at the
-censoring time of the exponential distribution with rate
-`lambda`.  The log likelihoods for the censored events could have
+The log likelihood contribution given censored items is the number of
+censored items times the log complementary cumulative distribution function
+(lccdf) at the censoring time of the exponential distribution with rate
+`lambda`.  The log likelihood terms arising from the censored events could have
 been added to the target log density one at a time,
 
 ```stan
@@ -273,8 +273,8 @@ the mode is nonzero ($t > 0$).
 
 ### Stan program {-}
 
-With Stan, one can just swap the exponential density for the Weibull
-density with the appropriate parameters and the model remains
+With Stan, one can just swap the exponential distribution for the Weibull
+distribution with the appropriate parameters and the model remains
 essentially the same.  Recall the exponential model's parameters and
 model block.
 
@@ -291,7 +291,8 @@ model {
 ```
 
 The Stan program for the Weibull model just swaps in the Weibull
-distribution with its shape (`alpha`) and scale (`sigma`) parameters.
+distribution and complementary cumulative distribution function
+with shape (`alpha`) and scale (`sigma`) parameters.
 
 ```stan
 parameters {
@@ -340,7 +341,7 @@ The censored items have probability
 \cdot \beta).
 \end{equation*}
 
-The the covariates form an $N \times K$ data matrix, $x \in
+The covariates form an $N \times K$ data matrix, $x \in
 \mathbb{R}^{N \times K}$. An intercept can be introduced by adding a
 column of 1 values to $x$.
 
@@ -368,9 +369,10 @@ model {
 }
 ```
 
-Both the censored and uncensored likelihoods are vectorized, one in
-terms of the log complementary cumulative distribution function and
-one in terms of the exponential distribution.
+Both the distribution statement for uncensored times and the
+log density increment statement for censored times are vectorized, one 
+in terms of the exponential distribution and one in
+terms of the log complementary cumulative distribution function.
 
 
 ## Hazard and survival functions
@@ -497,17 +499,20 @@ hazard function $h_0(t)$ is not modeled.  This is why it is called
 determines how individual $n$ varies by a proportion from the baseline
 hazard, is modeled.  This is why it's called "proportional hazards."
 
-The proportional hazards model is not fully generative.  There is no
+Cox's proportional hazards model is not fully generative.  There is no
 way to generate the times of failure because the baseline hazard
 function $h_0(t)$ is unmodeled; if the baseline hazard were known,
-failure times could be generated.  The proportional hazards model is
+failure times could be generated.  Cox's proportional hazards model is
 generative for the ordering of failures conditional on a number of
-censored items.
+censored items. Proportional hazard models may also include parametric
+or non-parametric model for the baseline hazard function^{Cox mentioned
+in his seminal paper that modeling the baseline hazard function would improve
+statistical efficiency, but he did not do it for computational reasons.}.
 
 
 ### Partial likelihood function {-}
 
-The proportional specification of the hazard function is insufficient
+Cox's proportional specification of the hazard function is insufficient
 to generate random variates because the baseline hazard function
 $h_0(t)$ is unknown.  On the other hand, the proportional
 specification is sufficient to generate a partial likelihood that

--- a/src/stan-users-guide/time-series.qmd
+++ b/src/stan-users-guide/time-series.qmd
@@ -409,7 +409,7 @@ model {
   phi ~ normal(0, 2);
   theta ~ normal(0, 2);
   sigma ~ cauchy(0, 5);
-  err ~ normal(0, sigma);    // likelihood
+  err ~ normal(0, sigma);    // error model
 }
 ```
 
@@ -421,7 +421,7 @@ and `err` the errors.  These are computed similarly to the
 errors in the moving average models described in the previous section.
 
 The priors are weakly informative for stationary processes.  The
-likelihood only involves the error term, which is efficiently
+data model only involves the error term, which is efficiently
 vectorized here.
 
 Often in models such as these, it is desirable to inspect the
@@ -753,7 +753,7 @@ transformed data {
 }
 ```
 
-The likelihood component of the model based on looping over the input
+The data model component based on looping over the input
 is replaced with multinomials as follows.
 
 ```stan

--- a/src/stan-users-guide/truncation-censoring.qmd
+++ b/src/stan-users-guide/truncation-censoring.qmd
@@ -190,13 +190,15 @@ location and scale, it is not necessary to impute values.  Instead,
 the values can be integrated out.  Each censored data point has a
 probability of
 \begin{align*}
-\Pr[y > U]
-  &= \int_U^{\infty} \textsf{normal}\left(y \mid \mu,\sigma \right) \,\textsf{d}y \\
+\Pr[y_{\mathrm{cens},m} > U]
+  &= \int_U^{\infty} \textsf{normal}\left(y_{\mathrm{cens},m} \mid \mu,\sigma \right) \,\textsf{d}y_{\mathrm{cens},m} \\
   &= 1 - \Phi\left(\frac{U - \mu}{\sigma}\right),
 \end{align*}
 
-where $\Phi()$ is the standard normal cumulative distribution function.
-With $M$ censored observations, the total probability on the log scale
+where $\Phi()$ is the standard normal cumulative distribution function. 
+This probability is equivalent to the likelihood contribution of knowing
+that $y_{\mathrm{cens},m}>U$.
+With $M$ censored observations, the likelihood on the log scale
 is
 \begin{align*}
 \log \prod_{m=1}^M \Pr[y_m > U]
@@ -206,7 +208,7 @@ is
 
 where `normal_lccdf` is the log of complementary CDF
 (Stan provides `<distr>_lccdf` for each distribution
-implemented in Stan).
+implemented in Stan). 
 
 The following right-censored model assumes
 that the censoring point is known, so it is declared as data.
@@ -229,9 +231,10 @@ model {
 ```
 
 For the observed values in `y_obs`, the normal model is
-used without truncation.  The log probability is directly incremented
-using the calculated log cumulative normal probability of the censored
-data items.
+used without truncation.  The likelihood contribution from the
+integrated out censored values can not be coded with distribution
+statement, and the log probability is directly incremented using the
+calculated log cumulative normal probability of the censored observations.
 
 For the left-censored data the CDF (`normal_lcdf`) has to be
 used instead of complementary CDF.  If the censoring point variable


### PR DESCRIPTION
Now that sampling statement has been changed to distribution statement, I continued checking the terms used
- checked that every mention of likelihood refers to likelihood, and replaced with more appropriate terms if referring to data model or distribution
- changed all "sampling distribution" to "data model" or something else, as 1) "sampling" word is heavily overloaded in the doc anyway and in some places it's not clear whether sampling is referring to sampling from the posterior, 2) "sampling distribution" has a frequentist usage which can mislead the reader in Bayesian modeling context
- changed "predictive likelihood" to "posterior predictive distribution"
- couple more distribution statements
- fixed some other sentences and added some clarifications
- fixed some typos
