### PR TITLE
Minor fix of Markdown syntax

### DIFF
--- a/src/reference-manual/expressions.qmd
+++ b/src/reference-manual/expressions.qmd
@@ -1340,7 +1340,7 @@ model {
 ```
 
 Algebraically, 
-[statements.qmd#distribution-statements.section](the distribution statement) 
+[the distribution statement](statements.qmd#distribution-statements.section)
 in the model could be reduced to
 
 ```stan


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

A minor fix of the Markdown syntax for referencing documents.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

None. Just a minor bug fix.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
