### PR TITLE
clarify empty array expression

### DIFF
--- a/src/reference-manual/expressions.qmd
+++ b/src/reference-manual/expressions.qmd
@@ -301,7 +301,7 @@ The empty expression `[ ]` is ambiguous and therefore is not
 allowed and similarly expressions such as `[ [ ] ]` or
 `[ [ ], [ ] ]` are not allowed.
 
-#### Empty vectors and matrices {-}
+### Empty vectors and matrices {-}
 
 If needed, it is possible to create an empty vector with
 ```stan
@@ -347,7 +347,7 @@ array[2, 3] int b = { { 1, 2, 3 },
                 { 4, 5, 6 } };
 ```
 
-#### Empty arrays {-}
+### Empty arrays {-}
 
 The empty array expression (`{ }`) is not allowed. See more about restrictions on array expressions in subsection [Restrictions on values](#array-expressions).
 

--- a/src/reference-manual/expressions.qmd
+++ b/src/reference-manual/expressions.qmd
@@ -334,7 +334,21 @@ array[2, 3] int b = { { 1, 2, 3 },
                 { 4, 5, 6 } };
 ```
 
+#### Empty arrays {-}
+
 The empty array expression (`{ }`) is not allowed. See more about restrictions on array expressions in subsection [Restrictions on values](#array-expressions).
+
+If needed, it is possible to create an empty array with
+```stan
+rep_array(e, 0)
+```
+where the first expression `e` determines the type of the array. For
+example, `rep_array(0.0, 0)` returns an empty real array of type
+`real[]`, whereas `rep_array({123}, 0)` returns an empty two
+dimensional integer array of type `int[ , ]`. Only the type of the
+first argument is used, so the integer arrays `{123}` and `{0}`
+produce equivalent values.
+
 
 ### Array expression types {-}
 
@@ -417,13 +431,6 @@ zero-element array.
 ```stan
 array[0] int a;   // a is fully defined as zero element array
 ```
-
-If needed, it is also possible to create an empty array with
-```stan
-rep_array(0, 0)
-```
-where the type of the first argument determines the type of the array
-(e.g., real or int).
 
 #### No zero-tuples or one-tuples {-}
 

--- a/src/reference-manual/expressions.qmd
+++ b/src/reference-manual/expressions.qmd
@@ -301,6 +301,19 @@ The empty expression `[ ]` is ambiguous and therefore is not
 allowed and similarly expressions such as `[ [ ] ]` or
 `[ [ ], [ ] ]` are not allowed.
 
+#### Empty vectors and matrices {-}
+
+If needed, it is possible to create an empty vector with
+```stan
+rep_vector(e, 0)
+```
+where the first expression `e` needs to scalar of type `real`.
+
+If needed, it is possible to create an empty matrix with
+```stan
+rep_matrix(e, 0, 0)
+```
+where the first expression `e` needs to scalar of type `real`.
 
 ### Array expressions {-}
 

--- a/src/reference-manual/expressions.qmd
+++ b/src/reference-manual/expressions.qmd
@@ -334,6 +334,7 @@ array[2, 3] int b = { { 1, 2, 3 },
                 { 4, 5, 6 } };
 ```
 
+The empty array expression (`{ }`) is not allowed. See more about restrictions on array expressions in subsection [Restrictions on values](#array-expressions).
 
 ### Array expression types {-}
 
@@ -416,6 +417,13 @@ zero-element array.
 ```stan
 array[0] int a;   // a is fully defined as zero element array
 ```
+
+If needed, it is also possible to create an empty array with
+```stan
+rep_array(0, 0)
+```
+where the type of the first argument determines the type of the array
+(e.g., real or int).
 
 #### No zero-tuples or one-tuples {-}
 


### PR DESCRIPTION
Fixes #621

The restriction on empty array expression is mentioned later, but it is easy to miss, so clarified it now also earlier with link to the later section. Also added the suggested way to create an empty array.