### PR TITLE
fix and clarify exp_mod_normal parameter names, fixes #429

### DIFF
--- a/src/functions-reference/unbounded_continuous_distributions.qmd
+++ b/src/functions-reference/unbounded_continuous_distributions.qmd
@@ -380,6 +380,8 @@ and scale `sigma` dropping constant additive terms.
 
 ## Exponentially modified normal distribution
 
+Exponentially modified Gaussian describes the distribution of $Z = X + Y$ when $X$ and $Y$ are independent and $X$ is normally distributed (with mean $\mu$ and standard deviation $\sigma$) and $Y$ is exponentially distributed (with rate $\lambda$).
+
 ### Probability density function
 
 If $\mu \in \mathbb{R}$, $\sigma \in \mathbb{R}^+$, and $\lambda \in
@@ -405,7 +407,7 @@ Increment target log probability density with `exp_mod_normal_lupdf(y | mu, sigm
 
 `real` **`exp_mod_normal_lpdf`**`(reals y | reals mu, reals sigma, reals lambda)`<br>\newline
 The log of the exponentially modified normal density of y given
-location mu, scale sigma, and shape lambda
+location mu, scale sigma, and rate lambda
 {{< since 2.18 >}}
 
 <!-- real; exp_mod_normal_lupdf; (reals y | reals mu, reals sigma, reals lambda); -->
@@ -413,7 +415,7 @@ location mu, scale sigma, and shape lambda
 
 `real` **`exp_mod_normal_lupdf`**`(reals y | reals mu, reals sigma, reals lambda)`<br>\newline
 The log of the exponentially modified normal density of y given
-location mu, scale sigma, and shape lambda dropping constant additive terms
+location mu, scale sigma, and rate lambda dropping constant additive terms
 {{< since 2.25 >}}
 
 <!-- real; exp_mod_normal_cdf; (reals y | reals mu, reals sigma, reals lambda); -->
@@ -421,7 +423,7 @@ location mu, scale sigma, and shape lambda dropping constant additive terms
 
 `real` **`exp_mod_normal_cdf`**`(reals y | reals mu, reals sigma, reals lambda)`<br>\newline
 The exponentially modified normal cumulative distribution function of
-y given location mu, scale sigma, and shape lambda
+y given location mu, scale sigma, and rate lambda
 {{< since 2.0 >}}
 
 <!-- real; exp_mod_normal_lcdf; (reals y | reals mu, reals sigma, reals lambda); -->
@@ -429,7 +431,7 @@ y given location mu, scale sigma, and shape lambda
 
 `real` **`exp_mod_normal_lcdf`**`(reals y | reals mu, reals sigma, reals lambda)`<br>\newline
 The log of the exponentially modified normal cumulative distribution
-function of y given location mu, scale sigma, and shape lambda
+function of y given location mu, scale sigma, and rate lambda
 {{< since 2.18 >}}
 
 <!-- real; exp_mod_normal_lccdf; (reals y | reals mu, reals sigma, reals lambda); -->
@@ -437,7 +439,7 @@ function of y given location mu, scale sigma, and shape lambda
 
 `real` **`exp_mod_normal_lccdf`**`(reals y | reals mu, reals sigma, reals lambda)`<br>\newline
 The log of the exponentially modified normal complementary cumulative
-distribution function of y given location mu, scale sigma, and shape
+distribution function of y given location mu, scale sigma, and rate
 lambda
 {{< since 2.18 >}}
 
@@ -446,7 +448,7 @@ lambda
 
 `R` **`exp_mod_normal_rng`**`(reals mu, reals sigma, reals lambda)`<br>\newline
 Generate a exponentially modified normal variate with location mu,
-scale sigma, and shape lambda; may only be used in transformed data and generated
+scale sigma, and rate lambda; may only be used in transformed data and generated
 quantities blocks. For a description of argument and return types, see
 section [vectorized PRNG functions](conventions_for_probability_functions.qmd#prng-vectorization).
 {{< since 2.18 >}}


### PR DESCRIPTION
fixes #429 

Used Wikipedia naming https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution, and added one sentence to clarify the role of the different parameters.