### PR TITLE
cross-link reverse functions to not miss other supported types

### DIFF
--- a/src/functions-reference/array_operations.qmd
+++ b/src/functions-reference/array_operations.qmd
@@ -545,7 +545,7 @@ Number of components of v less than v[s]
 Number of components of v less than v[s]
 {{< since 2.0 >}}
 
-## Reversing functions {#reversing-functions}
+## Reverse functions {#reverse-functions}
 
 Stan provides functions to create a new array by reversing the order of
 elements in an existing array. For example, if `v` is declared as a real
@@ -564,3 +564,5 @@ then
 `array[] T` **`reverse`**`(array[] T v)`<br>\newline
 Return a new array containing the elements of the argument in reverse order.
 {{< since 2.23 >}}
+
+See also `reverse` functions for [vectors](matrix_operations.qmd#reverse-functions) and [complex vectors](complex_matrix_operations.qmd#reverse-functions).

--- a/src/functions-reference/complex_matrix_operations.qmd
+++ b/src/functions-reference/complex_matrix_operations.qmd
@@ -1481,7 +1481,7 @@ computational cost due to the shared work between the two results.
 
 
 
-## Reverse functions for complex matrices
+## Reverse functions {#reverse-functions}
 
 <!-- complex_vector; reverse; (complex_vector v); -->
 \index{{\tt \bfseries reverse }!{\tt (complex\_vector v): complex\_vector}|hyperpage}
@@ -1497,3 +1497,5 @@ computational cost due to the shared work between the two results.
  Return a new row vector containing the elements of the argument in reverse
  order.
  {{< since 2.30 >}}
+
+See also `reverse` functions for [arrays](array_operations.qmd#reverse-functions) and [vectors](matrix_operations.qmd#reverse-functions).

--- a/src/functions-reference/matrix_operations.qmd
+++ b/src/functions-reference/matrix_operations.qmd
@@ -2486,3 +2486,5 @@ Return a new vector containing the elements of the argument in reverse order.
 `row_vector` **`reverse`**`(row_vector v)`<br>\newline
 Return a new row vector containing the elements of the argument in reverse order.
 {{< since 2.23 >}}
+
+See also `reverse` functions for [arrays](array_operations.qmd#reverse-functions) and [complex vectors](complex_matrix_operations.qmd#reverse-functions).


### PR DESCRIPTION
fixes #798 

unified also the section and anchor names