### PR TITLE
Clarify meaning of "set flag" in cmdstan-guide

### DIFF
--- a/src/cmdstan-guide/parallelization.qmd
+++ b/src/cmdstan-guide/parallelization.qmd
@@ -21,7 +21,9 @@ on how to rewrite Stan models to use these functions see [Stan's User guide chap
 Once a model is rewritten to use the above-mentioned functions, the model
 must be compiled with the `STAN_THREADS` makefile flag. The flag can be
 supplied in the `make` call but we recommend writing the flag to the
-`make/local` file.
+`make/local` file. If the `STAN_THREADS` flag is set to any non-empty value,
+threads will be enabled.
+
 
 An example of the contents of `make/local` to enable threading with TBB:
 
@@ -77,7 +79,7 @@ implementations are [MPICH](https://www.mpich.org/) and [OpenMPI](https://www.op
 Once a model is rewritten to use `map_rect`, additional makefile flags
 must be written to the `make/local`. These are:
 
-- `STAN_MPI`: Enables the use of MPI with Stan if `true`.
+- `STAN_MPI`: Enables the use of MPI with Stan if set.
 - `CXX`: The name of the MPI C++ compiler wrapper. Typically `mpicxx`.
 - `TBB_CXX_TYPE`: The C++ compiler the MPI wrapper wraps. Typically `gcc` on Linux and `clang` on macOS.
 
@@ -158,8 +160,8 @@ Follow Intel's install instructions given [here](https://software.intel.com/cont
 ### Compiling
 
 In order to enable the OpenCL backend the model
-must be compiled with the `STAN_OPENCL` makefile flag. The flag can be
-supplied in the `make` call but we recommend writing the flag to the
+must be compiled with the `STAN_OPENCL` makefile flag set (to any non-empty value).
+The flag can be supplied in the `make` call but we recommend writing the flag to the
 `make/local` file.
 
 An example of the contents of `make/local` to enable parallelization
@@ -169,7 +171,7 @@ with OpenCL:
 STAN_OPENCL=true
 ```
 
-If you are using OpenCL with an integrated GPU you also need to add the `INTEGRATED_OPENCL` flag, as the sharing of memory between CPU and GPU is slightly different with integrated graphics:
+If you are using OpenCL with an integrated GPU you also need to set the `INTEGRATED_OPENCL` flag, as the sharing of memory between CPU and GPU is slightly different with integrated graphics:
 
 ```
 INTEGRATED_OPENCL=true

--- a/src/cmdstan-guide/parallelization.qmd
+++ b/src/cmdstan-guide/parallelization.qmd
@@ -21,7 +21,7 @@ on how to rewrite Stan models to use these functions see [Stan's User guide chap
 Once a model is rewritten to use the above-mentioned functions, the model
 must be compiled with the `STAN_THREADS` makefile flag. The flag can be
 supplied in the `make` call but we recommend writing the flag to the
-`make/local` file. If the `STAN_THREADS` flag is set to any non-empty value,
+`make/local` file. If the `STAN_THREADS` flag is defined/non-empty,
 threads will be enabled.
 
 
@@ -79,7 +79,7 @@ implementations are [MPICH](https://www.mpich.org/) and [OpenMPI](https://www.op
 Once a model is rewritten to use `map_rect`, additional makefile flags
 must be written to the `make/local`. These are:
 
-- `STAN_MPI`: Enables the use of MPI with Stan if set.
+- `STAN_MPI`: Enables the use of MPI with Stan if defined.
 - `CXX`: The name of the MPI C++ compiler wrapper. Typically `mpicxx`.
 - `TBB_CXX_TYPE`: The C++ compiler the MPI wrapper wraps. Typically `gcc` on Linux and `clang` on macOS.
 
@@ -160,7 +160,7 @@ Follow Intel's install instructions given [here](https://software.intel.com/cont
 ### Compiling
 
 In order to enable the OpenCL backend the model
-must be compiled with the `STAN_OPENCL` makefile flag set (to any non-empty value).
+must be compiled with the `STAN_OPENCL` makefile flag defined/non-empty.
 The flag can be supplied in the `make` call but we recommend writing the flag to the
 `make/local` file.
 
@@ -171,7 +171,7 @@ with OpenCL:
 STAN_OPENCL=true
 ```
 
-If you are using OpenCL with an integrated GPU you also need to set the `INTEGRATED_OPENCL` flag, as the sharing of memory between CPU and GPU is slightly different with integrated graphics:
+If you are using OpenCL with an integrated GPU you also need to define the `INTEGRATED_OPENCL` flag, as the sharing of memory between CPU and GPU is slightly different with integrated graphics:
 
 ```
 INTEGRATED_OPENCL=true


### PR DESCRIPTION

#### Submission Checklist

- [x] Builds locally
- [N/A] New functions marked with `` <<{ since VERSION }>>`` 
- [x] Declare copyright holder and open-source license: see below

#### Summary
State explicitly that setting `STAN_THREADS`, `STAN_MPI`, and `STAN_OPENCL` to any value, including falsy values, turns the corresponding feature on.

Fix https://github.com/stan-dev/cmdstan/issues/1293


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Max Planck Institute of Animal Behavior


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
