### PR TITLE
Fix typo: ls -> wc

### DIFF
--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -228,7 +228,7 @@ On Linux and macOS:
 
 # default output written to file `output.csv`,
 # default num_samples is 1000, output file should have approx. 1050 lines
-> ls -l output.csv
+> wc -l output.csv
 
 # run the `bin/stansummary utility to summarize parameter estimates
 > bin/stansummary output.csv


### PR DESCRIPTION
Fix issue #812 with a one word change changing `ls` to `wc`.

#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Janne Peltola

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
