### PR TITLE
Edit to macOS C++ install docs

### DIFF
--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -373,7 +373,7 @@ xcode-select --install
 Select "Install" in the window that opens.
 
 After the installation completes, you can double check that
-istallation was successful by reopening the Terminal and 
+installation was successful by reopening the Terminal and 
 running:
 ```
 clang++ --version

--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -380,6 +380,9 @@ clang++ --version
 make --version
 ```
 
+You can read more about Xcode on its site: 
+[https://developer.apple.com/xcode/](https://developer.apple.com/xcode/)
+
 We don't recommend trying to use the GNU C++ compiler, available via Homebrew,
 based on the number of reports of installation difficulties from Mac users on GitHub
 as well as the Stan forums.

--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -364,33 +364,20 @@ If either of these commands prints the message
 `command not found`, you will need to install Xcode's
 command line tools.
 
-To install a C++ development
-environment on a Mac, use Apple's Xcode development environment
-https://developer.apple.com/xcode/.
+Open the Terminal application and enter:
 
-From the [Xcode home page](https://developer.apple.com/xcode/)
-`View in Mac App Store`.
+```
+xcode-select --install
+```
 
-- From the App Store, click `Install`, enter an Apple ID, and wait
-for Xcode to finish installing.
--  Open the Xcode application, click top-level menu `Preferences`,
-click top-row button `Downloads`, click button for
-`Components`, click on the `Install` button to the right of
-the `Command Line Tools` entry, then wait for it to finish
-installing.
-- Click the top-level menu item `Xcode`, then click item `Quit
-Xcode` to quit.
+Select "Install" in the window that opens.
 
-To test, open the Terminal application and enter:
+After the installation completes, you can double check that
+istallation was successful by reopening the Terminal and 
+running:
 ```
 clang++ --version
 make --version
-```
-
-If you have installed XCode, but don't have `make`, you can install the
-XCode command-line tools via command:
-```
-xcode-select --install
 ```
 
 

--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -380,7 +380,9 @@ clang++ --version
 make --version
 ```
 
-
+We don't recommend trying to use the GNU C++ compiler, available via Homebrew,
+based on the number of reports of installation difficulties from Mac users on GitHub
+as well as the Stan forums.
 
 #### Windows {#windows}
 

--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -353,6 +353,17 @@ or cluster administrator to install these tools for you.
 
 #### MacOS
 
+To check if you already already have an appropriate toolchain
+installed, open the Terminal application and enter:
+```
+clang++ --version
+make --version
+```
+
+If either of these commands prints the message 
+`command not found`, you will need to install Xcode's
+command line tools.
+
 To install a C++ development
 environment on a Mac, use Apple's Xcode development environment
 https://developer.apple.com/xcode/.


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

As currently written, the C++ toolchain documentation for macOS sends users first to install Xcode from the app store. I've placed a check on whether clang++ and make are installed above that. I've also replaced the instructions to install Xcode from the app store with just the `xcode-select --install` instruction. My reasoning for this is:

##### Adding a check first

- It makes the MacOS instructions more parallel with the Linux and Windows instructions, which also have a checking step before an installation step.
- Some people who are less familiar with these tools may, nevertheless, have installed the Xcode command line tools previously, but don't necessarily remember that they have done so.
- The documented experience of what options are available, and what will happen, will be different depending on whether or not command line tools have already been installed.

##### Removing Xcode app install
The documented steps for installing command line tools through the Xcode app appear to be outdated at least by Xcode v15.4. There is no `Xcode>Preferences` menu, and under `Xcode>Settings`, there is no Downloads tab. In fact, poking around, it's not entirely clear to me _how_ to install command line tools within the Xcode app.

Installing command line tools with `xcode-select --install` still works, and involves fewer steps.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Josef Fruehwald



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
