### PR TITLE
Update custom-probability.qmd

### DIFF
--- a/src/stan-users-guide/custom-probability.qmd
+++ b/src/stan-users-guide/custom-probability.qmd
@@ -119,7 +119,7 @@ definition of the bivariate normal cumulative distribution function
 (CDF) with location zero, unit variance, and correlation `rho`.
 That is, it computes
 $$
-\texttt{binormal}\mathtt{\_}\texttt{cdf}(z_1, z_2, \rho) = \Pr[Z_1 > z_1 \text{ and } Z_2 > z_2]
+\texttt{binormal}\mathtt{\_}\texttt{cdf}(z_1, z_2, \rho) = \Pr[Z_1 \leq z_1 \text{ and } Z_2 \leq z_2]
 $$
 where the random 2-vector $Z$ has the distribution
 $$


### PR DESCRIPTION
Fix typo in documentation. Definition of bivariate normal CDF. Currently described in tutorial as pr (y1 > z1 and y2 > z2) whereas both should be leq. This is the standard defn of the CDF and what the `binormal_cdf` example provided actually computes. Verifiable in R:

```
test_binorm_cdf <- function(a,b,rho,nmc=1e5) {
    xx <- MASS::mvrnorm(nmc, c(0,0), matrix(c(1,rho,rho,1),2,2))
    mean(xx[,1]<a & xx[,2]<b)
}
```

#### Submission Checklist

- [x] Builds locally
- *NA* New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

**I waive any copyright claims.**

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
