### PR TITLE
Update one-dimensional-integrals.qmd

### DIFF
--- a/src/stan-users-guide/one-dimensional-integrals.qmd
+++ b/src/stan-users-guide/one-dimensional-integrals.qmd
@@ -48,13 +48,11 @@ not a function of our parameters.
 The function defining the integrand must have exactly the argument types and
 return type of `normal_density` above, though argument naming is not important.
 Even if `x_r` and `x_i` are unused in the integrand, they must be
-included in the function signature. This may require passing in zero-length arrays
-for data or parameters if the integral does not involve
-data or parameters. Creating zero length arrays is more complicated than creating
-non-zero-length arrays. For user defined integrand functions the non-used array arguments 
-can be passed as non-zero-length arrays with any content which can then be ignored 
-in the function. This way, for example, `{0}` can be passed for the non-used data and
-parameters array arguments.
+included in the function signature. Even if the integral does not involve some of these,
+they must still be supplied some value. The most efficient will be a zero-length array
+or vector, which can be created with rep_array(0, 0) and rep_vector(0, 0), respectively.
+Other options include an uninitialized variable declared with size 0, which is equivalent
+to the above, or any easy value, such as size 1 array created with {0}.
 
 ## Calling the integrator
 

--- a/src/stan-users-guide/one-dimensional-integrals.qmd
+++ b/src/stan-users-guide/one-dimensional-integrals.qmd
@@ -49,8 +49,12 @@ The function defining the integrand must have exactly the argument types and
 return type of `normal_density` above, though argument naming is not important.
 Even if `x_r` and `x_i` are unused in the integrand, they must be
 included in the function signature. This may require passing in zero-length arrays
-for data or a zero-length vector for parameters if the integral does not involve
-data or parameters.
+for data or parameters if the integral does not involve
+data or parameters. Creating zero length arrays is more complicated than creating
+non-zero-length arrays. For user defined integrand functions the non-used array arguments 
+can be passed as non-zero-length arrays with any content which can then be ignored 
+in the function. This way, for example, `{0}` can be passed for the non-used data and
+parameters array arguments.
 
 ## Calling the integrator
 


### PR DESCRIPTION
#### Summary

Clarify that `integrate_1d` non-used parameter and data arguments can be any arrays, e.g. `{0}`, if the integrand function does not use those arguments. Creating `{0}` is much easier than creating a zero-length array.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
