### PR TITLE
Fix rtools download links

### DIFF
--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -28,7 +28,7 @@ command `cmdstan_model` to activate the CmdStan makefile from anywhere.
 
 _Note_: This requires that conda has been installed already on your machine.
 We recommend using the [miniforge](https://github.com/conda-forge/miniforge)
-distribution. 
+distribution.
 
 We recommend installing CmdStan in a new conda environment:
 
@@ -358,7 +358,7 @@ clang++ --version
 make --version
 ```
 
-If either of these commands prints the message 
+If either of these commands prints the message
 `command not found`, you will need to install Xcode's
 command line tools.
 
@@ -371,14 +371,14 @@ xcode-select --install
 Select "Install" in the window that opens.
 
 After the installation completes, you can double check that
-installation was successful by reopening the Terminal and 
+installation was successful by reopening the Terminal and
 running:
 ```
 clang++ --version
 make --version
 ```
 
-You can read more about Xcode on its site: 
+You can read more about Xcode on its site:
 [https://developer.apple.com/xcode/](https://developer.apple.com/xcode/)
 
 We don't recommend trying to use the GNU C++ compiler, available via Homebrew,
@@ -422,7 +422,11 @@ UCRT is only natively supported on Windows 10 and newer, older systems will requ
 
 Download the installer and complete the prompts for installation:
 
- - [RTools44](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-6104-6039.exe)
+ - [RTools44](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-6335-6327.exe)
+
+If the above link no longer works, navigate [here](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/)
+and download the latest file which is named `rtools44-xxxx-yyyy.exe`
+(`x`s and `y`s will be different version numbers over time).
 
 Next, you need to add the toolchain directory to your `PATH` variable:
 ```
@@ -434,7 +438,11 @@ C:\rtools44\x86_64-w64-mingw32.static.posix\bin
 
 Download the installer and complete the prompts for installation:
 
- - [RTools44 - ARM64](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-aarch64-6104-6039.exe)
+ - [RTools44 - ARM64](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-aarch64-6335-6327.exe)
+
+If the above link no longer works, navigate [here](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/)
+and download the latest file which is named `rtools44-aarch64-xxxx-yyyy.exe`
+(`x`s and `y`s will be different version numbers over time).
 
 Next, you need to add the toolchain directory to your `PATH` variable:
 ```


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

These links go dead every now and then when rtools changes the sub-version numbers

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
