### PR TITLE
Issue 809 gp cov functions

### DIFF
--- a/src/bibtex/all.bib
+++ b/src/bibtex/all.bib
@@ -1867,6 +1867,7 @@ location = {Philadelphia}
   author={Magnusson, M{\aa}ns and Torgander, Jakob and B{\"u}rkner, Paul-Christian and Zhang, Lu and Carpenter, Bob and Vehtari, Aki},
   journal={arXiv preprint arXiv:2407.04967},
   year={2024}
+}
 
 @article{egozcue+etal:2003,
   title={Isometric logratio transformations for compositional data analysis},

--- a/src/stan-users-guide/gaussian-processes.qmd
+++ b/src/stan-users-guide/gaussian-processes.qmd
@@ -183,7 +183,7 @@ data {
   array[N] real x;
 }
 transformed data {
-  matrix[N, N] K = cov_exp_quad(x, 1.0, 1.0);
+  matrix[N, N] K = gp_exp_quad_cov(x, 1.0, 1.0);
   vector[N] mu = rep_vector(0, N);
   for (n in 1:N) {
     K[n, n] = K[n, n] + 0.1;
@@ -345,7 +345,7 @@ parameters {
 }
 model {
   matrix[N, N] L_K;
-  matrix[N, N] K = cov_exp_quad(x, alpha, rho);
+  matrix[N, N] K = gp_exp_quad_cov(x, alpha, rho);
   real sq_sigma = square(sigma);
 
   // diagonal elements
@@ -414,7 +414,7 @@ model {
   vector[N] f;
   {
     matrix[N, N] L_K;
-    matrix[N, N] K = cov_exp_quad(x, alpha, rho);
+    matrix[N, N] K = gp_exp_quad_cov(x, alpha, rho);
 
     // diagonal elements
     for (n in 1:N) {
@@ -550,12 +550,12 @@ modeled hierarchically.
 The implementation of automatic relevance determination in Stan is
 straightforward, though it currently requires the user to directly code the
 covariance matrix. We'll write a function to generate the Cholesky of the
-covariance matrix called `L_cov_exp_quad_ARD`.
+covariance matrix called `L_gp_exp_quad_cov_ARD`.
 
 
 ```stan
 functions {
-  matrix L_cov_exp_quad_ARD(array[] vector x,
+  matrix L_gp_exp_quad_cov_ARD(array[] vector x,
                             real alpha,
                             vector rho,
                             real delta) {
@@ -592,7 +592,7 @@ parameters {
 model {
   vector[N] f;
   {
-    matrix[N, N] L_K = L_cov_exp_quad_ARD(x, alpha, rho, delta);
+    matrix[N, N] L_K = L_gp_exp_quad_cov_ARD(x, alpha, rho, delta);
     f = L_K * eta;
   }
 
@@ -772,7 +772,7 @@ transformed parameters {
   vector[N] f;
   {
     matrix[N, N] L_K;
-    matrix[N, N] K = cov_exp_quad(x, alpha, rho);
+    matrix[N, N] K = gp_exp_quad_cov(x, alpha, rho);
 
     // diagonal elements
     for (n in 1:N) {
@@ -858,7 +858,7 @@ transformed parameters {
   vector[N] f;
   {
     matrix[N, N] L_K;
-    matrix[N, N] K = cov_exp_quad(x, alpha, rho);
+    matrix[N, N] K = gp_exp_quad_cov(x, alpha, rho);
 
     // diagonal elements
     for (n in 1:N) {
@@ -944,17 +944,17 @@ functions {
       matrix[N2, N2] cov_f2;
       matrix[N2, N2] diag_delta;
       matrix[N1, N1] K;
-      K = cov_exp_quad(x1, alpha, rho);
+      K = gp_exp_quad_cov(x1, alpha, rho);
       for (n in 1:N1) {
         K[n, n] = K[n, n] + square(sigma);
       }
       L_K = cholesky_decompose(K);
       K_div_y1 = mdivide_left_tri_low(L_K, y1);
       K_div_y1 = mdivide_right_tri_low(K_div_y1', L_K)';
-      k_x1_x2 = cov_exp_quad(x1, x2, alpha, rho);
+      k_x1_x2 = gp_exp_quad_cov(x1, x2, alpha, rho);
       f2_mu = (k_x1_x2' * K_div_y1);
       v_pred = mdivide_left_tri_low(L_K, k_x1_x2);
-      cov_f2 = cov_exp_quad(x2, alpha, rho) - v_pred' * v_pred;
+      cov_f2 = gp_exp_quad_cov(x2, alpha, rho) - v_pred' * v_pred;
       diag_delta = diag_matrix(rep_vector(delta, N2));
 
       f2 = multi_normal_rng(f2_mu, cov_f2 + diag_delta);
@@ -981,7 +981,7 @@ parameters {
 model {
   matrix[N1, N1] L_K;
   {
-    matrix[N1, N1] K = cov_exp_quad(x1, alpha, rho);
+    matrix[N1, N1] K = gp_exp_quad_cov(x1, alpha, rho);
     real sq_sigma = square(sigma);
 
     // diagonal elements
@@ -1095,7 +1095,7 @@ parameters {
 model {
   matrix[N, D] f;
   {
-    matrix[N, N] K = cov_exp_quad(x, 1.0, rho);
+    matrix[N, N] K = gp_exp_quad_cov(x, 1.0, rho);
     matrix[N, N] L_K;
 
     // diagonal elements


### PR DESCRIPTION
#### Submission Checklist

- [X] Builds locally
- [ ] New functions marked with `` <<{ since VERSION }>>``
- [X] Declare copyright holder and open-source license: see below

#### Summary

Fixes #809.

- Replaced uses of cov_exp_quad with gp_exp_quad_cov.
- Updated the names of user-defined functions in the Automatic relevance determination section to match.

Had to fix a missing } in all.bib for docs to build.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Louis Freeland-Haynes


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
