### PR TITLE
Add vector overload for trace_quad_form

### DIFF
--- a/src/functions-reference/functions_index.qmd
+++ b/src/functions-reference/functions_index.qmd
@@ -3722,12 +3722,13 @@ pagetitle: Alphabetical Index
 
 <a id='trace_gen_quad_form' href='#trace_gen_quad_form' class='anchored unlink'>**trace_gen_quad_form**:</a>
 
- - <div class='index-container'>[`(matrix D,matrix A, matrix B) : real`](matrix_operations.qmd#index-entry-518a194d883c53498ccdcf91b73a6a385ecc99b7) <span class='detail'>(matrix_operations.html)</span></div>
+ - <div class='index-container'>[`(matrix D ,matrix A, matrix B) : real`](matrix_operations.qmd#index-entry-725c7c07b916a247f645ce441212b4a82778b096) <span class='detail'>(matrix_operations.html)</span></div>
 
 
 <a id='trace_quad_form' href='#trace_quad_form' class='anchored unlink'>**trace_quad_form**:</a>
 
  - <div class='index-container'>[`(matrix A, matrix B) : real`](matrix_operations.qmd#index-entry-9e673dba39e3d7e6297d26eda1aaa01ff737cd89) <span class='detail'>(matrix_operations.html)</span></div>
+ - <div class='index-container'>[`(matrix A, vector B) : real`](matrix_operations.qmd#index-entry-4102366e38a8c1eb82e650b1867da9a37385278a) <span class='detail'>(matrix_operations.html)</span></div>
 
 
 <a id='trigamma' href='#trigamma' class='anchored unlink'>**trigamma**:</a>

--- a/src/functions-reference/matrix_operations.qmd
+++ b/src/functions-reference/matrix_operations.qmd
@@ -746,10 +746,17 @@ A is symmetric and ensures that the result is also symmetric.
 The trace of the quadratic form, i.e., `trace(B' * A * B)`.
 {{< since 2.0 >}}
 
-<!-- real; trace_gen_quad_form; (matrix D,matrix A, matrix B); -->
-\index{{\tt \bfseries trace\_gen\_quad\_form }!{\tt (matrix D,matrix A, matrix B): real}|hyperpage}
+<!-- real; trace_quad_form; (matrix A, vector B); -->
+\index{{\tt \bfseries trace\_quad\_form }!{\tt (matrix A, vector B): real}|hyperpage}
 
-`real` **`trace_gen_quad_form`**`(matrix D,matrix A, matrix B)`<br>\newline
+`real` **`trace_quad_form`**`(matrix A, vector B)`<br>\newline
+The trace of the quadratic form, i.e., `trace(B' * A * B)`.
+{{< since 2.0 >}}
+
+<!-- real; trace_gen_quad_form; (matrix D ,matrix A, matrix B); -->
+\index{{\tt \bfseries trace\_gen\_quad\_form }!{\tt (matrix D, matrix A, matrix B): real}|hyperpage}
+
+`real` **`trace_gen_quad_form`**`(matrix D, matrix A, matrix B)`<br>\newline
 The trace of a generalized quadratic form, i.e., `trace(D * B' * A *
 B).`
 {{< since 2.0 >}}


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Closes #860 

It seems this overload has been available at least as long as the matrix,matrix one, so I listed 2.0 as the version

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
