### PR TITLE
Bugfix/844 neals funnel refs

### DIFF
--- a/src/stan-users-guide/efficiency-tuning.qmd
+++ b/src/stan-users-guide/efficiency-tuning.qmd
@@ -267,9 +267,6 @@ function applied to $y$.  A plot of the log marginal density of $y$
 and the first dimension $x_1$ is shown in the following plot.
 
 
-The marginal density of Neal's funnel for the upper-level variable $y$ and one lower-level variable $x_1$ (see the text for the formula).  The blue region has log density greater than -8, the yellow region density greater than -16, and the gray background a density less than -16.
-
-![Neal's funnel density](img/funnel.png)
 
 The funnel can be implemented directly in Stan as follows.
 
@@ -289,16 +286,23 @@ the neck of the funnel, where $y$ is small and thus $x$ is constrained
 to be near 0.  This is due to the fact that the density's scale
 changes with $y$, so that a step size that works well in the body will
 be too large for the neck, and a step size that works in the neck will be
-inefficient in the body.  This can be seen in the following plot.
+inefficient in the body.  This can be seen in the following plots.
 
-4000 draws are taken from a run of Stan's sampler with default settings.  Both
-plots are restricted to the shown window of $x_1$ and $y$ values; some
-draws fell outside of the displayed area as would be expected given
+::: {#fig-funnel layout="[55, 45]"}
+
+![](img/funnel.png)
+
+![](img/funnel-fit.png)
+
+
+Neal's funnel.  (Left) The marginal density of Neal's funnel for the upper-level variable $y$ and one lower-level variable $x_1$ (see the text for the formula).  The blue region has log density greater than -8, the yellow region density greater than -16, and the gray background a density less than -16.
+(Right) 4000 draws are taken from a run of Stan's sampler with default settings.
+Both plots are restricted to the shown window of $x_1$ and $y$ values;
+some draws fell outside of the displayed area as would be expected given
 the density.  The samples are consistent with the marginal density
 $p(y) = \textsf{normal}(y \mid 0,3)$, which has mean 0 and standard
 deviation 3.
-
-![](img/funnel-fit.png)
+:::
 
 In this particular instance, because the analytic form of the density
 from which samples are drawn is known, the model can be converted to

--- a/src/stan-users-guide/regression.qmd
+++ b/src/stan-users-guide/regression.qmd
@@ -875,7 +875,8 @@ y_n     & \sim \textsf{normal}(x_n \beta, \sigma) \\
 In this case, as $\tau \rightarrow 0$ and $\beta_k \rightarrow 0$, the
 posterior density
 $$ p(\beta,\tau,\sigma|y,x) \propto p(y|x,\beta,\tau,\sigma) $$
-grows without bound.  See the [plot of Neal's funnel density](#funnel.figure), which has similar behavior.
+grows without bound.
+See the [Neal's funnel density](efficiency-tuning.qmd#funnel.figure), which has similar behavior.
 
 There is obviously no MLE estimate for $\beta,\tau,\sigma$ in such a
 case, and therefore the model must be modified if posterior modes are


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [ ] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Neal's funnel section plots now side-by-side, with caption relating the two plots.

With this change, the plots now match the plots in the original version.  When the latex sources were converted to bookdown format, the figure was broken up, presumably because bookdown didn't support fancy figures.   Now that we're using Quarto, this is again possible; putting them together makes the narrative much more coherent.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):  Columbia University



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
