### PR TITLE
Make it easier to find vector concatenation

### DIFF
--- a/src/functions-reference/matrix_operations.qmd
+++ b/src/functions-reference/matrix_operations.qmd
@@ -1430,9 +1430,9 @@ i.e., elements i through through i + n - 1. Applies to up to
 three-dimensional arrays containing any type of elements `T`.
 {{< since 2.0 >}}
 
-## Matrix concatenation {#matrix-concatenation}
+## Matrix and vector concatenation {#matrix-concatenation}
 
-Stan's matrix concatenation operations `append_col` and `append_row`
+Stan's matrix and vector concatenation operations `append_col` and `append_row`
 are like the operations `cbind` and `rbind` in R.
 
 #### Horizontal concatenation


### PR DESCRIPTION
It took me a moment to find functions for vector concatenation. Changing the section title from "Matrix concatenation" to "Matrix and vector concatenation" makes it easier to find the relevant section.