### PR TITLE
Update windows toolchain docs to RTools45

### DIFF
--- a/src/cmdstan-guide/installation.qmd
+++ b/src/cmdstan-guide/installation.qmd
@@ -397,20 +397,20 @@ g++ --version
 make --version
 ```
 
-CmdStan is known compatible with the RTools44 toolchain. The toolchain will require
+CmdStan is known compatible with the RTools45 toolchain. The toolchain will require
 updating your `PATH` variable, See [these instructions](https://helpdeskgeek.com/windows-10/add-windows-path-environment-variable/)
 for details on changing the `PATH` if you are unfamiliar. The following instructions will assume that the default installation
 directory was used, so be sure to update the paths accordingly if you have chosen a different
 directory.
 
 
-##### RTools44
+##### RTools45
 
 All required utilities (e.g., `make`, `g++`) for compiling and running CmdStan models on Windows are
-provided by the RTools44 toolchain from the R Project. Installation steps are provided below,
-and for more technical details on the toolchain refer to the [R Project documentation](https://cran.r-project.org/bin/windows/Rtools/rtools44/rtools.html).
+provided by the RTools45 toolchain from the R Project. Installation steps are provided below,
+and for more technical details on the toolchain refer to the [R Project documentation](https://cran.r-project.org/bin/windows/Rtools/rtools45/rtools.html).
 
-The R Project provides RTools44 for both Intel/AMD 64-bit (x86_64) and ARM 64-bit (aarch64) systems.
+The R Project provides RTools45 for both Intel/AMD 64-bit (x86_64) and ARM 64-bit (aarch64) systems.
 If you are unsure which to use, then you can check by going to the Windows Settings, selecting the 'System' menu and then the 'About' option.
 If the 'System Type' field lists 'ARM-based processor', then you should follow the ARM64 instructions below.
 
@@ -422,32 +422,24 @@ UCRT is only natively supported on Windows 10 and newer, older systems will requ
 
 Download the installer and complete the prompts for installation:
 
- - [RTools44](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-6335-6327.exe)
-
-If the above link no longer works, navigate [here](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/)
-and download the latest file which is named `rtools44-xxxx-yyyy.exe`
-(`x`s and `y`s will be different version numbers over time).
+ - [RTools45](https://github.com/r-hub/rtools45/releases/download/latest/rtools45.exe)
 
 Next, you need to add the toolchain directory to your `PATH` variable:
 ```
-C:\rtools44\usr\bin
-C:\rtools44\x86_64-w64-mingw32.static.posix\bin
+C:\rtools45\usr\bin
+C:\rtools45\x86_64-w64-mingw32.static.posix\bin
 ```
 
 ###### Installation - ARM 64-bit (arm64/aarch64)
 
 Download the installer and complete the prompts for installation:
 
- - [RTools44 - ARM64](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/rtools44-aarch64-6335-6327.exe)
-
-If the above link no longer works, navigate [here](https://cran.r-project.org/bin/windows/Rtools/rtools44/files/)
-and download the latest file which is named `rtools44-aarch64-xxxx-yyyy.exe`
-(`x`s and `y`s will be different version numbers over time).
+ - [RTools45 - ARM64](https://github.com/r-hub/rtools45/releases/download/latest/rtools45-aarch64.exe)
 
 Next, you need to add the toolchain directory to your `PATH` variable:
 ```
-C:\rtools44-aarch64\usr\bin
-C:\rtools44-aarch64\aarch64-w64-mingw32.static.posix\bin
+C:\rtools45-aarch64\usr\bin
+C:\rtools45-aarch64\aarch64-w64-mingw32.static.posix\bin
 ```
 
 ## Using GNU Make {#gnu-make}


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Updates the Windows Toolchain docs for RTools to use RTools45.

I've also updated the download URLs to use the stable download URLs provided by the r-hub project: https://github.com/r-hub/rtools45

These are used by the `r-lib/setup-r` Github action, so they seem pretty robust

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Andrew Johnson



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
