### PR TITLE
Documentation Fixes for Stan User's Guide

### DIFF
--- a/src/stan-users-guide/gaussian-processes.qmd
+++ b/src/stan-users-guide/gaussian-processes.qmd
@@ -98,7 +98,7 @@ and
 $$
   K_2(x \mid \sigma)_{i, j}
 =
- \delta_{i, j} \sigma^2,
+ \delta_{i, j} \sigma^2.
 $$
 
 The addition of $\sigma^2$ on the diagonal is important
@@ -124,7 +124,7 @@ if an input vector $x$ is translated by a vector $\epsilon$ to $x +
 $K(x \mid \theta) = K(x + \epsilon \mid \theta)$.
 
 The summation involved is just the squared Euclidean distance between
-$x_i$ and $x_j$ (i.e., the $L_2$ norm of their difference, $x_i -
+$x_i$ and $x_j$ (i.e., the squared $L_2$ norm of their difference, $x_i -
 x_j$). This results in support for smooth functions in the process.
 The amount of variation in the function is controlled by the free
 hyperparameters $\alpha$, $\rho$, and $\sigma$.
@@ -234,9 +234,9 @@ A more efficient implementation of the simulation model can be
 coded in Stan by relocating, rescaling and rotating an isotropic standard
 normal variate.  Suppose $\eta$ is an an isotropic standard normal variate
 $$
-\eta \sim \textsf{normal}(\textbf{0}, \textbf{1}),
+\eta \sim \textsf{normal}(\textbf{0}, \textrm{I}),
 $$
-where $\textbf{0}$ is an $N$-vector of 0 values and $\textbf{1}$ is the $N
+where $\textbf{0}$ is an $N$-vector of 0 values and $\textrm{I}$ is the $N
 \times N$ identity matrix.  Let $L$ be the Cholesky decomposition of
 $K(x \mid \theta)$, i.e., the lower-triangular matrix $L$ such that $LL^{\top} =
 K(x \mid \theta)$.  Then the transformed variable $\mu + L\eta$ has the intended
@@ -686,7 +686,7 @@ If we have high-frequency covariates in our fixed effects, we may wish to
 further regularize the GP away from high-frequency functions, which means we'll
 need to penalize smaller length-scales. Luckily, we have a useful way of
 thinking about how length-scale affects the frequency of the functions
-supported the GP. If we were to repeatedly draw from a zero-mean GP with a
+supported by the GP. If we were to repeatedly draw from a zero-mean GP with a
 length-scale of $\rho$ in a fixed-domain $[0,T]$, we would get a distribution
 for the number of times each draw of the GP crossed the zero axis. The
 expectation of this random variable, the number of zero crossings, is $T / \pi

--- a/src/stan-users-guide/regression.qmd
+++ b/src/stan-users-guide/regression.qmd
@@ -540,7 +540,8 @@ In a Bayesian setting, a proper prior on each of the $\beta$ is enough
 to identify the model.  Unfortunately, this can lead to inefficiency
 during sampling as the model is still only weakly identified through
 the prior---there is a very simple example of the difference in
-the discussion of collinearity in @collinearity.section.
+the discussion of collinearity in the
+[collinearity section](problematic-posteriors.qmd#collinearity.section).
 
 An alternative identification strategy that allows a symmetric prior
 is to enforce a sum-to-zero constraint on the varying effects, i.e.,

--- a/src/stan-users-guide/time-series.qmd
+++ b/src/stan-users-guide/time-series.qmd
@@ -463,7 +463,7 @@ A halfway point would be to vectorize just `err`.
 
 MA and ARMA models are not identifiable if the roots of the
 characteristic polynomial for the MA part lie inside the unit circle,
-so it's necessary to add the following constraint^[This subsection is a lightly edited comment of Jonathan Gilligan's on GitHub; see \url{https://github.com/stan-dev/stan/issues/1617\#issuecomment-160249142}]
+so it's necessary to add the following constraint^[This subsection is a lightly edited comment of Jonathan Gilligan's on GitHub; see [https://github.com/stan-dev/stan/issues/1617\#issuecomment-160249142](https://github.com/stan-dev/stan/issues/1617\#issuecomment-160249142).]
 
 ```stan
 real<lower=-1, upper=1> theta;


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

A few documentation fixes for Stan User's Guide:

- `regression.qmd`: The syntax `@collinearity.section` looks like a reference citation, but it is actually intended to link to the `problematic-posteriors.qmd#collinearity.section` section.
- `time-series.qmd`: The LaTeX-type command `\url{}` does not work for HTML output, so I change it to a Markdown hyperlink.
- `gaussian-processes.qmd`: It is not common to use `\textbf{1}` to stand for an identity matrix, and I change it to the more standard notation `\textrm{I}`. There are a few other more obvious fixes.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

None. Just a few minor bug fixes.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
