### PR TITLE
Update Typo in blocks.qmd

### DIFF
--- a/src/reference-manual/blocks.qmd
+++ b/src/reference-manual/blocks.qmd
@@ -296,7 +296,7 @@ supplied to the program at run time, they must be declared in the
 `data` block, like the variables `mu_mu` and
 `sigma_mu`.
 
-This program declares two modeled parameters, `mu` and
+This program declares two modeled parameters, `mu_y` and
 `tau_y`.  These are the location and precision used in the normal
 model of the values in `y`.  The heart of the model will be
 sampling the values of these parameters from their posterior


### PR DESCRIPTION
The example model is specified with parameters `mu_y` and `sigma_y`. I assume the missing index `y` was a typo :)

#### Submission Checklist

- [ ] Builds locally
- [ ] New functions marked with `` <<{ since VERSION }>>``
- [ ] Declare copyright holder and open-source license: see below

#### Summary

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
