### PR TITLE
Removed claim that Stan doesn't support MAP

### DIFF
--- a/src/stan-users-guide/clustering.qmd
+++ b/src/stan-users-guide/clustering.qmd
@@ -563,9 +563,8 @@ replaced with a multivariate logistic normal distribution.
 
 The authors treat the prior as a fixed hyperparameter.  They use an
 $L_1$-regularized estimate of covariance, which is equivalent to the
-maximum a posteriori estimate given a double-exponential prior.  Stan
-does not (yet) support maximum a posteriori estimation, so the mean and
-covariance of the multivariate logistic normal must be specified as
+maximum a posteriori estimate given a double-exponential prior.  Here
+the mean and covariance of the multivariate logistic normal are specified as
 data.
 
 #### Fixed hyperparameter correlated topic model {-}


### PR DESCRIPTION
#### Summary

The user guide had "Stan does not (yet) support maximum a posteriori estimation", which is not true. Stan supports both MAP in constrained space (without Jacobian) and MAP in unconstrained space (with Jacobian). I removed that part of the sentence.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Aki Vehtari

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
