### PR TITLE
Fix copy/paste error in qr() documentation

### DIFF
--- a/src/functions-reference/matrix_operations.qmd
+++ b/src/functions-reference/matrix_operations.qmd
@@ -2359,8 +2359,8 @@ dimensions as A
 \index{{\tt \bfseries qr }!{\tt (matrix A): tuple(matrix, matrix)}|hyperpage}
 `tuple(matrix, matrix)` **`qr`**`(matrix A)`<br>\newline
 Returns both portions of the QR decomposition of A. The first element ("Q") is
-the orthonormal matrix in the thin QR decomposition and the second element ("R")
-is upper triangular. This function is equivalent to `(qr_Q(A), qr_R(A))` but
+the orthogonal matrix in the fat QR decomposition and the second element ("R")
+is upper trapezoidal. This function is equivalent to `(qr_Q(A), qr_R(A))` but
 with a lower computational cost due to the shared work between the two results.
 {{< since 2.33 >}}
 


### PR DESCRIPTION

#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fix a cut-and-paste error in the documentation for `qr()` - the second sentence was identical to that of `qr_thin`, which was incorrect.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):



By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
