### PR TITLE
document new integrate_1d_* functions

### DIFF
--- a/src/functions-reference/deprecated_functions.qmd
+++ b/src/functions-reference/deprecated_functions.qmd
@@ -188,6 +188,97 @@ solver,
 be passed to the system function
 
 
+## integrate_1d 1D integrator {#functions-old-1d-integrator}
+
+This function has been replaced by those described in
+[1D integrators](higher-order_functions.qmd#functions-1d-integrator).
+
+### Specifying an integrand as a function
+
+Performing a 1D integration requires the integrand to be specified somehow.
+This is done by defining a function in the Stan functions block with the special signature:
+
+```stan
+real integrand(real x, real xc, array[] real theta,
+               array[] real x_r, array[] int x_i)
+```
+
+The function should return the value of the integrand evaluated at
+the point x.
+
+The argument of this function are:
+
+* *`x`*, the independent variable being integrated over
+
+* *`xc`*, a high precision version of the distance from x to the nearest endpoint in a definite integral (for more into see section [Precision Loss](#precision-loss)).
+
+* *`theta`*, parameter values used to evaluate the integral
+
+* *`x_r`*, data values used to evaluate the integral
+
+* *`x_i`*, integer data used to evaluate the integral
+
+Like algebraic solver and the differential equations solver, the 1D
+integrator separates parameter values, `theta`, from data values, `x_r`.
+
+### Call to the 1D integrator
+
+<!-- real; integrate_1d; (function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i); -->
+\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, array[] real theta, array[] real x\_r, array[] int x\_i): real}|hyperpage}
+
+`real` **`integrate_1d`** `(function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i)`<br>\newline
+Integrates the integrand from a to b.
+{{< since 2.23 >}}
+
+<!-- real; integrate_1d; (function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i, real relative_tolerance); -->
+\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, array[] real theta, array[] real x\_r, array[] int x\_i, real relative\_tolerance): real}|hyperpage}
+
+`real` **`integrate_1d`** `(function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i, real relative_tolerance)`<br>\newline
+Integrates the integrand from a to b with the given relative tolerance.
+{{< since 2.23 >}}
+
+
+#### Arguments to the 1D integrator
+
+The arguments to the 1D integrator are as follows:
+
+* *`integrand`*: function literal referring to a function specifying the integrand with signature  `(real, real, array[] real, array[] real, array[] int):real`
+The arguments represent
+    + (1) where integrand is evaluated,
+    + (2) distance from evaluation point to integration limit for definite integrals,
+    + (3) parameters,
+    + (4) real data
+    + (5) integer data, and the return value is the integrand evaluated at the given point,
+
+* *`a`*: left limit of integration, may be negative infinity, type `real`,
+* *`b`*: right limit of integration, may be positive infinity, type `real`,
+* *`theta`*: parameters only, type `array[] real`,
+* *`x_r`*: real data only, type `array[] real`,
+* *`x_i`*: integer data only, type `array[] int`.
+
+A `relative_tolerance` argument can optionally be provided for more control over the algorithm:
+
+* *`relative_tolerance`*: relative tolerance for the 1d integrator, type `real`, data only.
+
+#### Return value
+
+The return value for the 1D integrator is a `real`, the value of the integral.
+
+#### Zero-crossing integrals {#zero-crossing}
+
+For numeric stability, integrals on the (possibly infinite) interval $(a, b)$ that cross zero are split into two integrals, one from $(a, 0)$ and one from $(0, b)$. Each integral is separately integrated to the given `relative_tolerance`.
+
+#### Precision loss near limits of integration in definite integrals {#precision-loss}
+
+When integrating certain definite integrals, there can be significant precision loss in evaluating the integrand near the endpoints. This has to do with the breakdown in precision of double precision floating point values when adding or subtracting a small number from a number much larger than it in magnitude (for instance, `1.0 - x`). `xc` (as passed to the integrand) is a high-precision version of the distance between `x` and the definite integral endpoints and can be used to address this issue. More information (and an example where this is useful) is given in the User's Guide. For zero crossing integrals, `xc` will be a high precision version of the distance to the endpoints of the two smaller integrals. For any integral with an endpoint at negative infinity or positive infinity, `xc` is set to `NaN`.
+
+#### Algorithmic details
+
+Internally the 1D integrator uses the double-exponential methods in the Boost 1D quadrature library. Boost in turn makes use of quadrature methods developed in [@Takahasi:1974], [@Mori:1978], [@Bailey:2005], and [@Tanaka:2009].
+
+The gradients of the integral are computed in accordance with the Leibniz integral rule. Gradients of the integrand are computed internally with Stan's automatic differentiation.
+
+
 ## algebra_solver, algebra_solver_newton algebraic solvers {#functions-old-algebra-solver}
 
 These algebraic solver functions have been replaced by those described in

--- a/src/functions-reference/higher-order_functions.qmd
+++ b/src/functions-reference/higher-order_functions.qmd
@@ -534,101 +534,158 @@ initial state derivatives passed into the solver, and length of each vector in t
 *   number of solution times and number of vectors in the output.
 
 
-## 1D integrator {#functions-1d-integrator}
+## 1D integrators {#functions-1d-integrator}
 
-Stan provides a built-in mechanism to perform 1D integration of a function via quadrature methods.
+Stan provides built-in 1D integrators using adaptive quadrature.
+`integrate_1d_double_exponential` uses
+double-exponential quadrature; `integrate_1d_gauss_kronrod` uses adaptive
+Gauss-Kronrod quadrature. They differ in which integrands they handle
+well (see [Algorithmic details](#integrator-algorithmic-details)):
+double-exponential quadrature is robust to algebraic or logarithmic
+singularities at the integration limits, while Gauss-Kronrod is more
+accurate on smooth integrands and on integrands whose mass lies away
+from the limits.
 
-It operates similarly to the [algebraic solver](#functions-algebraic-solver) and
-the [ordinary differential equations solver](#functions-ode-solver) in that it allows as an argument a function.
-
-Like both of those utilities, some of the arguments are limited
-to data only expressions. These expressions must not contain variables
-other than those declared in the data or transformed data blocks.
+A 1D integrator is a higher-order function, i.e. it takes another
+function as one of its arguments. Like the algebraic solvers and the
+differential equation solvers, some arguments are restricted to data
+only; these must not contain variables other than those declared in the
+data or transformed data blocks.
 
 ### Specifying an integrand as a function
 
-Performing a 1D integration requires the integrand to be specified somehow.
-This is done by defining a function in the Stan functions block with the special signature:
+The integrand is specified as an ordinary function in Stan within the
+functions block. The function must return a `real` and takes as its
+first two arguments the variable of integration `x` and its complement
+`xc`, both `real`. These are followed by variadic arguments `...` passed
+through unmodified from the integrator call:
 
 ```stan
-real integrand(real x, real xc, array[] real theta,
-               array[] real x_r, array[] int x_i)
+ real integrand(real x, real xc, ...)
 ```
 
-The function should return the value of the integrand evaluated at
-the point x.
+The function should return the value of the integrand evaluated at `x`.
+The arguments are:
 
-The argument of this function are:
+* *`x`*, the variable being integrated over,
 
-* *`x`*, the independent variable being integrated over
+* *`xc`*, for definite integrals, a high-precision version of the
+distance from `x` to the nearest integration limit (see
+[Algorithmic details](#integrator-algorithmic-details) for its use); set
+to `NaN` for integrals with an infinite limit, and always `NaN` for
+`integrate_1d_gauss_kronrod`,
 
-* *`xc`*, a high precision version of the distance from x to the nearest endpoint in a definite integral (for more into see section [Precision Loss](#precision-loss)).
-
-* *`theta`*, parameter values used to evaluate the integral
-
-* *`x_r`*, data values used to evaluate the integral
-
-* *`x_i`*, integer data used to evaluate the integral
-
-Like algebraic solver and the differential equations solver, the 1D
-integrator separates parameter values, `theta`, from data values, `x_r`.
+* *`...`*, variadic arguments passed unmodified from the integrator call.
+The types here must match the types of the `...` arguments of the
+integrator call. There is no type restriction; mark data arguments with
+the keyword `data`.
 
 ### Call to the 1D integrator
 
-<!-- real; integrate_1d; (function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i); -->
-\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, array[] real theta, array[] real x\_r, array[] int x\_i): real}|hyperpage}
+<!-- real; integrate_1d_double_exponential; (function integrand, real a, real b, ...); -->
+\index{{\tt \bfseries integrate\_1d\_double\_exponential }!{\tt (function integrand, real a, real b, ...): real}|hyperpage}
+`real` **`integrate_1d_double_exponential`**`(function integrand, real a, real b, ...)`<br>\newline
+Integrates the integrand from a to b using double-exponential quadrature.
 
-`real` **`integrate_1d`** `(function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i)`<br>\newline
-Integrates the integrand from a to b.
-{{< since 2.23 >}}
+<!-- real; integrate_1d_double_exponential_tol; (function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_refinements, ...); -->
+\index{{\tt \bfseries integrate\_1d\_double\_exponential\_tol }!{\tt (function integrand, real a, real b, data real relative\_tolerance, data real absolute\_tolerance, data int max\_refinements, ...): real}|hyperpage}
+`real` **`integrate_1d_double_exponential_tol`**`(function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_refinements, ...)`<br>\newline
+Integrates the integrand from a to b using double-exponential quadrature with additional control parameters.
 
-<!-- real; integrate_1d; (function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i, real relative_tolerance); -->
-\index{{\tt \bfseries integrate\_1d }!{\tt (function integrand, real a, real b, array[] real theta, array[] real x\_r, array[] int x\_i, real relative\_tolerance): real}|hyperpage}
+<!-- real; integrate_1d_gauss_kronrod; (function integrand, real a, real b, ...); -->
+\index{{\tt \bfseries integrate\_1d\_gauss\_kronrod }!{\tt (function integrand, real a, real b, ...): real}|hyperpage}
+`real` **`integrate_1d_gauss_kronrod`**`(function integrand, real a, real b, ...)`<br>\newline
+Integrates the integrand from a to b using Gauss-Kronrod quadrature.
 
-`real` **`integrate_1d`** `(function integrand, real a, real b, array[] real theta, array[] real x_r, array[] int x_i, real relative_tolerance)`<br>\newline
-Integrates the integrand from a to b with the given relative tolerance.
-{{< since 2.23 >}}
-
+<!-- real; integrate_1d_gauss_kronrod_tol; (function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_depth, ...); -->
+\index{{\tt \bfseries integrate\_1d\_gauss\_kronrod\_tol }!{\tt (function integrand, real a, real b, data real relative\_tolerance, data real absolute\_tolerance, data int max\_depth, ...): real}|hyperpage}
+`real` **`integrate_1d_gauss_kronrod_tol`**`(function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_depth, ...)`<br>\newline
+Integrates the integrand from a to b using Gauss-Kronrod quadrature with additional control parameters.
 
 #### Arguments to the 1D integrator
 
-The arguments to the 1D integrator are as follows:
+The arguments to the 1D integrators are as follows:
 
-* *`integrand`*: function literal referring to a function specifying the integrand with signature  `(real, real, array[] real, array[] real, array[] int):real`
-The arguments represent
-    + (1) where integrand is evaluated,
-    + (2) distance from evaluation point to integration limit for definite integrals,
-    + (3) parameters,
-    + (4) real data
-    + (5) integer data, and the return value is the integrand evaluated at the given point,
+* *`integrand`*: function literal referring to the integrand, with
+signature `(real, real, ...): real`; the arguments represent (1) where
+the integrand is evaluated, (2) the distance from the evaluation point to
+the nearest integration limit for definite integrals, and (3) the
+variadic arguments, and the return value is the integrand evaluated at
+the given point,
 
-* *`a`*: left limit of integration, may be negative infinity, type `real`,
-* *`b`*: right limit of integration, may be positive infinity, type `real`,
-* *`theta`*: parameters only, type `array[] real`,
-* *`x_r`*: real data only, type `array[] real`,
-* *`x_i`*: integer data only, type `array[] int`.
+* *`a`*: left limit of integration, may be negative infinity (`negative_infinity()`), type `real`,
+* *`b`*: right limit of integration, may be positive infinity (`positive_infinity()`), type `real`,
+* *`...`*: variadic arguments.
 
-A `relative_tolerance` argument can optionally be provided for more control over the algorithm:
+The `_tol` variants take control parameters before the variadic
+arguments. All are data only:
 
-* *`relative_tolerance`*: relative tolerance for the 1d integrator, type `real`, data only.
+* *`relative_tolerance`*: relative tolerance of the integrator, type `real`,
+* *`absolute_tolerance`*: absolute-error floor on the convergence test, type `real`,
+* *`max_refinements`* (`integrate_1d_double_exponential_tol` only): maximum number of refinement levels, type `int`,
+* *`max_depth`* (`integrate_1d_gauss_kronrod_tol` only): maximum recursive bisection depth, type `int`.
 
 #### Return value
 
-The return value for the 1D integrator is a `real`, the value of the integral.
+The return value for the 1D integrators is a `real`, the value of the
+integral.
 
-#### Zero-crossing integrals {#zero-crossing}
+#### Algorithmic details {#integrator-algorithmic-details}
 
-For numeric stability, integrals on the (possibly infinite) interval $(a, b)$ that cross zero are split into two integrals, one from $(a, 0)$ and one from $(0, b)$. Each integral is separately integrated to the given `relative_tolerance`.
+Both integrators use quadrature methods from the Boost library; Boost in
+turn builds on methods developed in [@Takahasi:1974], [@Mori:1978],
+[@Bailey:2005], and [@Tanaka:2009].
 
-#### Precision loss near limits of integration in definite integrals {#precision-loss}
+`integrate_1d_double_exponential` uses the double-exponential methods
+`tanh_sinh`, `exp_sinh`, or `sinh_sinh`, chosen by the finiteness of the
+limits. Its nodes concentrate near the integration limits, which makes it
+robust to algebraic or logarithmic singularities of the integrand at the
+endpoints (for instance the beta density $x^{\alpha-1}(1-x)^{\beta-1}$
+with small $\alpha$, $\beta$). For numeric stability, integrals on the
+(possibly infinite) interval $(a, b)$ that cross zero are split into two
+integrals, one over $(a, 0)$ and one over $(0, b)$, each integrated
+separately to the requested tolerances.
 
-When integrating certain definite integrals, there can be significant precision loss in evaluating the integrand near the endpoints. This has to do with the breakdown in precision of double precision floating point values when adding or subtracting a small number from a number much larger than it in magnitude (for instance, `1.0 - x`). `xc` (as passed to the integrand) is a high-precision version of the distance between `x` and the definite integral endpoints and can be used to address this issue. More information (and an example where this is useful) is given in the User's Guide. For zero crossing integrals, `xc` will be a high precision version of the distance to the endpoints of the two smaller integrals. For any integral with an endpoint at negative infinity or positive infinity, `xc` is set to `NaN`.
+`integrate_1d_gauss_kronrod` uses adaptive Gauss-Kronrod quadrature with
+a 21-point Kronrod rule. Its nodes cover the whole interval, so it is
+more accurate than double-exponential quadrature on smooth integrands and
+on integrands whose mass lies away from the limits (off-centre peaks),
+which the double-exponential nodes can undersample. It applies no
+endpoint transform and does not split zero-crossing integrals; integrands
+with endpoint singularities should use `integrate_1d_double_exponential`
+instead. Infinite limits are handled internally by a change of variable.
 
-#### Algorithmic details
+The integration succeeds when
+$$
+  \text{error} \leq \max(\text{relative\_tolerance} \cdot |I|,
+  \text{absolute\_tolerance}),
+$$
+where $|I|$ is the estimated $L_1$ norm of the integral. With
+`absolute_tolerance = 0` (the default in the non-`_tol` variants) this is
+a pure relative-tolerance test. A positive `absolute_tolerance` lets the
+integration succeed when $|I|$ is so small that the relative test is
+dominated by accumulated floating-point round-off, for instance when the
+integrand is essentially zero across the interval (as happens with nested
+integration in the tails of a density). If an integrator cannot reach the
+requested tolerance an exception is raised; in the model block this
+rejects the current proposal, and in generated quantities the returned
+value is `NaN`. A larger tolerance can then be specified.
 
-Internally the 1D integrator uses the double-exponential methods in the Boost 1D quadrature library. Boost in turn makes use of quadrature methods developed in [@Takahasi:1974], [@Mori:1978], [@Bailey:2005], and [@Tanaka:2009].
+For definite integrals, the `xc` argument passed to the integrand is a
+high-precision version of the distance from `x` to the nearest
+integration limit ($a - x$ near the lower limit, $b - x$ near the upper
+limit). It avoids the precision loss of forming, for example, `1.0 - x`
+for `x` near 1 in double-precision floating point, and is useful for
+integrands that are singular or near-singular at an endpoint. It is `NaN`
+for any integral with an infinite limit, and always `NaN` for
+`integrate_1d_gauss_kronrod`. For zero-crossing integrals it is a
+high-precision distance to the limits of each of the two sub-integrals.
+An example of its use is given in the User's Guide.
 
-The gradients of the integral are computed in accordance with the Leibniz integral rule. Gradients of the integrand are computed internally with Stan's automatic differentiation.
+The gradients of the integral are computed in accordance with the Leibniz
+integral rule. Gradients of the integrand are computed internally with
+Stan's automatic differentiation.
+
 
 ## Reduce-sum function {#functions-reduce}
 

--- a/src/functions-reference/higher-order_functions.qmd
+++ b/src/functions-reference/higher-order_functions.qmd
@@ -586,21 +586,25 @@ the keyword `data`.
 \index{{\tt \bfseries integrate\_1d\_double\_exponential }!{\tt (function integrand, real a, real b, ...): real}|hyperpage}
 `real` **`integrate_1d_double_exponential`**`(function integrand, real a, real b, ...)`<br>\newline
 Integrates the integrand from a to b using double-exponential quadrature.
+{{< since 2.40 >}}
 
 <!-- real; integrate_1d_double_exponential_tol; (function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_refinements, ...); -->
 \index{{\tt \bfseries integrate\_1d\_double\_exponential\_tol }!{\tt (function integrand, real a, real b, data real relative\_tolerance, data real absolute\_tolerance, data int max\_refinements, ...): real}|hyperpage}
 `real` **`integrate_1d_double_exponential_tol`**`(function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_refinements, ...)`<br>\newline
 Integrates the integrand from a to b using double-exponential quadrature with additional control parameters.
+{{< since 2.40 >}}
 
 <!-- real; integrate_1d_gauss_kronrod; (function integrand, real a, real b, ...); -->
 \index{{\tt \bfseries integrate\_1d\_gauss\_kronrod }!{\tt (function integrand, real a, real b, ...): real}|hyperpage}
 `real` **`integrate_1d_gauss_kronrod`**`(function integrand, real a, real b, ...)`<br>\newline
 Integrates the integrand from a to b using Gauss-Kronrod quadrature.
+{{< since 2.40 >}}
 
 <!-- real; integrate_1d_gauss_kronrod_tol; (function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_depth, ...); -->
 \index{{\tt \bfseries integrate\_1d\_gauss\_kronrod\_tol }!{\tt (function integrand, real a, real b, data real relative\_tolerance, data real absolute\_tolerance, data int max\_depth, ...): real}|hyperpage}
 `real` **`integrate_1d_gauss_kronrod_tol`**`(function integrand, real a, real b, data real relative_tolerance, data real absolute_tolerance, data int max_depth, ...)`<br>\newline
 Integrates the integrand from a to b using Gauss-Kronrod quadrature with additional control parameters.
+{{< since 2.40 >}}
 
 #### Arguments to the 1D integrator
 

--- a/src/functions-reference/higher-order_functions.qmd
+++ b/src/functions-reference/higher-order_functions.qmd
@@ -629,6 +629,11 @@ arguments. All are data only:
 * *`max_refinements`* (`integrate_1d_double_exponential_tol` only): maximum number of refinement levels, type `int`,
 * *`max_depth`* (`integrate_1d_gauss_kronrod_tol` only): maximum recursive bisection depth, type `int`.
 
+The non-`_tol` variants use the default control parameters
+`relative_tolerance` equal to the square root of the machine epsilon of
+double-precision floating point (about `1e-8`), `absolute_tolerance`
+equal to `0`, and `max_refinements` / `max_depth` equal to `15`.
+
 #### Return value
 
 The return value for the 1D integrators is a `real`, the value of the

--- a/src/stan-users-guide/one-dimensional-integrals.qmd
+++ b/src/stan-users-guide/one-dimensional-integrals.qmd
@@ -6,12 +6,13 @@ pagetitle: Computing One Dimensional Integrals
 
 
 Definite and indefinite one dimensional integrals can be performed in Stan
-using the [`integrate_1d` function](https://mc-stan.org/docs/functions-reference/higher-order_functions.html#functions-1d-integrator)
+using the [1D integrators](https://mc-stan.org/docs/functions-reference/higher-order_functions.html#functions-1d-integrator),
+`integrate_1d_double_exponential` and `integrate_1d_gauss_kronrod`.
 
 As an example, the normalizing constant of a left-truncated normal distribution is
 
 $$
-  \int_a^\infty \frac{1}{\sqrt{2 \pi \sigma^2}} e^{-\frac{1}{2}\frac{(x - \mu)^2}{\sigma^2}}
+  \int_a^\infty \frac{1}{\sqrt{2 \pi \sigma^2}} e^{-\frac{1}{2}\frac{(x - \mu)^2}{\sigma^2}}.
 $$
 
 
@@ -20,15 +21,11 @@ To compute this integral in Stan, the integrand must first be defined as a Stan 
 for more information on coding user-defined functions).
 
 ```stan
-real normal_density(real x,             // Function argument
-                    real xc,            // Complement of function argument
-                                        //  on the domain (defined later)
-                    array[] real theta, // parameters
-                    array[] real x_r,   // data (real)
-                    array[] int x_i) {  // data (integer)
-  real mu = theta[1];
-  real sigma = theta[2];
-
+real normal_density(real x,      // Function argument
+                    real xc,     // Complement of function argument
+                                 //  on the domain (defined later)
+                    real mu,     // mean
+                    real sigma) {  // standard deviation
   return 1 / (sqrt(2 * pi()) * sigma) * exp(-0.5 * ((x - mu) / sigma)^2);
 }
 ```
@@ -37,22 +34,17 @@ real normal_density(real x,             // Function argument
 This function is expected to return the value of the integrand evaluated at point `x`. The
 argument `xc` is used in definite integrals to avoid loss of precision near
 the limits of integration and is set to NaN when either limit is infinite
-(see the  section on precision/loss in the chapter on
+(see the section on precision loss in the chapter on
 Higher-Order Functions
-of the Stan Functions Reference for details on how to use this).
-The argument `theta` is used to pass in arguments of the integral
-that are a function of the parameters in our model. The arguments `x_r`
-and `x_i` are used to pass in real and integer arguments of the integral that are
-not a function of our parameters.
+of the Stan Functions Reference for details on how to use this). For
+`integrate_1d_gauss_kronrod`, `xc` is always NaN.
 
-The function defining the integrand must have exactly the argument types and
-return type of `normal_density` above, though argument naming is not important.
-Even if `x_r` and `x_i` are unused in the integrand, they must be
-included in the function signature. Even if the integral does not involve some of these,
-they must still be supplied some value. The most efficient will be a zero-length array
-or vector, which can be created with rep_array(0, 0) and rep_vector(0, 0), respectively.
-Other options include an uninitialized variable declared with size 0, which is equivalent
-to the above, or any easy value, such as size 1 array created with {0}.
+The arguments after `xc` are variadic: any number of arguments of any
+type may follow, and they are passed unmodified from the integrator call
+to the integrand. They may be data or parameters; arguments that are only
+ever data should be marked with the `data` keyword for efficiency, since
+extra parameter arguments increase the cost of propagating derivatives
+through the integral.
 
 ## Calling the integrator
 
@@ -72,11 +64,6 @@ data {
   array[N] real y;
 }
 
-transformed data {
-  array[0] real x_r;
-  array[0] int x_i;
-}
-
 parameters {
   real mu;
   real<lower=0.0> sigma;
@@ -88,12 +75,25 @@ model {
   sigma ~ normal(0, 1);
   left_limit ~ normal(0, 1);
   target += normal_lpdf(y | mu, sigma);
-  target += -log(integrate_1d(normal_density,
-                              left_limit,
-                              positive_infinity(),
-                              { mu, sigma }, x_r, x_i));
+  target += -log(integrate_1d_double_exponential(normal_density,
+                                                 left_limit,
+                                                 positive_infinity(),
+                                                 mu, sigma));
 }
 ```
+
+### Choosing the integrator {-}
+
+`integrate_1d_double_exponential` is robust to algebraic or logarithmic
+singularities of the integrand at the integration limits, and provides
+the `xc` argument for working near those limits (see [Avoiding precision
+loss](#integral-precision)). `integrate_1d_gauss_kronrod` is more
+accurate on smooth integrands and on integrands whose mass lies away
+from the limits (for example a normal density times a smooth function),
+but it cannot resolve endpoint singularities and always passes `xc` as
+NaN. The two functions share the same call signature; see the
+[1D integrators](https://mc-stan.org/docs/functions-reference/higher-order_functions.html#functions-1d-integrator)
+section of the Functions Reference for details.
 
 ### Limits of integration {-}
 
@@ -106,10 +106,10 @@ If both limits are either `negative_infinity()` or
 
 ### Data vs. parameters {-}
 
-The arguments for the real data `x_r` and the integer data `x_i`
-must be expressions that only involve data or transformed data variables.
-`theta`, on the other hand, can be a function of data, transformed data,
-parameters, or transformed parameters.
+The variadic arguments passed to the integrand may be data or parameters.
+Arguments that only ever involve data or transformed data variables
+should be marked with the `data` keyword, which avoids the extra cost of
+propagating derivatives through them.
 
 The endpoints of integration can be data or parameters (and internally the
 derivatives of the integral with respect to the endpoints are handled
@@ -117,39 +117,56 @@ with the Leibniz integral rule).
 
 ## Integrator convergence
 
-The integral is performed with the iterative 1D double exponential quadrature methods implemented
-in the Boost library [@BoostQuadrature:2017]. If the $n$th estimate of the
-integral is denoted $I_n$ and the $n$th estimate of the norm of the integral is
-denoted $|I|_n$, the iteration is terminated when
+The integral is performed with iterative quadrature methods implemented
+in the Boost library [@BoostQuadrature:2017]. The integration succeeds
+when
 
 $$
-  \frac{{|I_{n + 1} - I_n|}}{{|I|_{n + 1}}} < \text{relative tolerance}.
+  \text{error} \leq \max(\text{relative\_tolerance} \cdot |I|,
+  \text{absolute\_tolerance}),
 $$
 
-The `relative_tolerance` parameter can be optionally specified as the
-last argument to `integrate_1d`. By default, `integrate_1d` follows the
-Boost library recommendation of setting `relative_tolerance` to the square
-root of the machine epsilon of double precision floating point numbers
-(about `1e-8`). If the Boost integrator is not able to reach the relative tolerance
-an exception is raised with a message somehing like "Exception: integrate: error
-estimate of integral 4.25366e-13 exceeds the given relative tolerance times norm of integral".
-If `integrate_1d` causes an exception in transformed parameters block or model block, the
-result has the same effect as assigning a $-\infty$ log probability, which causes rejection 
-of the current proposal in MCMC samplers and adjustment of search parameters in optimization.
-If `integrate_1d` causes an exception in generated quantities block, the returned output from
-`integrate_1d` is NaN. In these cases, a bigger `relative_tolerance` value can be specified.
+where $|I|$ is the estimated norm of the integral. The tolerances and the
+maximum iteration count can be set through the `_tol` variants
+(`integrate_1d_double_exponential_tol` and
+`integrate_1d_gauss_kronrod_tol`), which take `relative_tolerance`,
+`absolute_tolerance`, and `max_refinements` (`max_depth` for the
+Gauss-Kronrod variant) before the variadic arguments. The non-`_tol`
+variants use `relative_tolerance` equal to the square root of the machine
+epsilon of double precision floating point numbers (about `1e-8`) and
+`absolute_tolerance` equal to zero, which reduces the test to a pure
+relative-tolerance criterion.
+
+A positive `absolute_tolerance` lets the integration succeed when $|I|$ is
+so small that the relative-tolerance test is dominated by floating-point
+round-off, for instance when the integrand is essentially zero across the
+interval (as happens with nested integration in the tails of a density).
+
+If the integrator cannot reach the requested tolerance an exception is
+raised with a message like "Exception: integrate: error estimate of
+integral 4.25366e-13 exceeds max(relative_tolerance * L1,
+absolute_tolerance)". If this occurs in the transformed parameters or
+model block, the result has the same effect as assigning a $-\infty$ log
+probability, which causes rejection of the current proposal in MCMC
+samplers and adjustment of search parameters in optimization. If it
+occurs in the generated quantities block, the returned value is NaN. In
+these cases, a larger tolerance can be specified.
 
 ### Zero-crossing integrals {- #zero-crossing}
 
-Integrals on the (possibly infinite) interval $(a, b)$ that cross zero are
-split into two integrals, one from $(a, 0)$ and one from $(0, b)$. This is
-because the quadrature methods employed internally can have difficulty near
-zero.
-
-In this case, each integral is separately integrated to the given
-`relative_tolerance`.
+When using `integrate_1d_double_exponential`, integrals on the (possibly
+infinite) interval $(a, b)$ that cross zero are split into two integrals,
+one from $(a, 0)$ and one from $(0, b)$, because the double-exponential
+quadrature can have difficulty near zero. Each integral is separately
+integrated to the given tolerances. `integrate_1d_gauss_kronrod` does not
+split zero-crossing integrals.
 
 ### Avoiding precision loss near limits of integration in definite integrals {- #integral-precision}
+
+The `xc` argument used in this section is provided by
+`integrate_1d_double_exponential`; `integrate_1d_gauss_kronrod` always
+passes `xc` as NaN, so these techniques apply when using the
+double-exponential integrator.
 
 If care is not taken, the quadrature can suffer from numerical loss of
 precision near the endpoints of definite integrals.
@@ -169,10 +186,7 @@ Normalizing this distribution requires computing the integral of $p(x)$ from
 zero to one. In Stan code, the integrand might look like:
 
 ```stan
-real beta(real x, real xc, array[] real theta, array[] real x_r, array[] int x_i) {
-  real alpha = theta[1];
-  real beta = theta[2];
-
+real beta(real x, real xc, real alpha, real beta) {
   return x^(alpha - 1.0) * (1.0 - x)^(beta - 1.0);
 }
 ```
@@ -188,9 +202,7 @@ or `b - x` for a lower endpoint `a` and an upper endpoint `b`. To make use of
 this for the beta integral, the integrand can be re-coded:
 
 ```stan
-real beta(real x, real xc, array[] real theta, array[] real x_r, array[] int x_i) {
-  real alpha = theta[1];
-  real beta = theta[2];
+real beta(real x, real xc, real alpha, real beta) {
   real v;
 
   if(x > 0.5) {
@@ -235,18 +247,9 @@ real shift_lognormal_pdf(real x,
 Therefore, the function that we want to integrate is:
 
 ```stan
-real integrand(real x,
-               real xc,
-               array[] real theta,
-               array[] real x_r,
-               array[] int x_i) {
+real integrand(real x, real xc, real mu, real sigma, real delta, real b) {
   real numerator;
   real p;
-
-  real mu = theta[1];
-  real sigma = theta[2];
-  real delta = theta[3];
-  real b = theta[4];
 
   p = shift_lognormal_pdf(x, mu, sigma, delta);
 
@@ -264,18 +267,9 @@ near zero, leading to a breakdown.
 We can use `xc`, and define the `integrand` as:
 
 ```stan
-real integrand(real x,
-               real xc,
-               array[] real theta,
-               array[] real x_r,
-               array[] int x_i) {
+real integrand(real x, real xc, real mu, real sigma, real delta, real b) {
   real numerator;
   real p;
-
-  real mu = theta[1];
-  real sigma = theta[2];
-  real delta = theta[3];
-  real b = theta[4];
 
   if (x < delta + 1) {
     p = shift_lognormal_pdf(xc, mu, sigma, delta);
@@ -308,3 +302,55 @@ $a < 0$ and $b > 0$) and `xc` is a high precision version of the distance
 to the limits of each of the two integrals separately. This means `xc` will
 be a high precision version of `a - x`, `x`, or `b - x`,
 depending on the value of x and the endpoints.
+
+## Example: integrating out a latent variable with Gauss-Kronrod
+
+A common use of 1D integration is to compute a marginal likelihood by
+integrating out a latent variable. Consider a Poisson count `y_i` with a
+per-observation varying intercept `z` given a normal prior
+`z ~ normal(0, sigmaz)`, and a linear predictor `mu_i`. The likelihood
+marginal over `z` is
+
+$$
+  p(y_i \mid \mu_i, \sigma_z) =
+  \int_{-\infty}^{\infty}
+  \text{normal}(z \mid 0, \sigma_z)\,
+  \text{Poisson}(y_i \mid e^{z + \mu_i})\, dz,
+$$
+
+a normal density times a Poisson probability mass function. The integrand
+is
+
+```stan
+real integrand(real z, real notused, real sigmaz, real mu_i, data int y_i) {
+  real p = exp(normal_lpdf(z | 0, sigmaz)
+               + poisson_log_lpmf(y_i | z + mu_i));
+  return (is_inf(p) || is_nan(p)) ? 0 : p;
+}
+```
+
+The `notused` argument is the `xc` slot, which `integrate_1d_gauss_kronrod`
+always passes as NaN; `y_i` is marked `data` because it is never a
+parameter; and the `is_inf`/`is_nan` guard returns 0 where `exp`
+over- or under-flows in the tails.
+
+Because the normal factor has thin tails, essentially all of the
+integrand's mass lies within `8 * sigmaz` of zero (at the limits the
+normal density is about $e^{-32}$ of its peak), so the integral can be
+taken over the finite interval $[-8\,\sigma_z,\ 8\,\sigma_z]$.
+Gauss-Kronrod places its nodes across the whole interval and resolves the
+peak — which sits near the conditional mode of `z`, away from zero when
+the count is large — where double-exponential quadrature over an infinite
+interval can undersample. In `generated quantities`, where `mu_i` is the
+linear predictor for observation `i` and `sigmaz` is a parameter,
+
+```stan
+log_lik[i] = log(integrate_1d_gauss_kronrod(integrand,
+                                            -8 * sigmaz,
+                                            8 * sigmaz,
+                                            sigmaz, mu_i, y[i]));
+```
+
+The variadic arguments `sigmaz`, `mu_i`, and `y[i]` are passed directly to
+the integrand, with no packing into data and parameter arrays, and the
+integration limits depend on the parameter `sigmaz`, which is allowed.


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Document new variadic `integrate_1d_double_exponential` and `integrate_1d_gauss_kronrod` functions, and moves `integrate_1d` to the deprecated-functions appendix.

Closes #953 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Aki Vehtari

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)

#### AI Use Disclosure

Editing was assisted by Claude as most text stayed the same. Functions reference mixes material from how algebraic solver section with several variadic functions is structured, existing integrate_1d text, and gauss_kronrod descriptions from a math PR. Users guide was updated to use variadic arguments and new example for gauss_kronrod follows my roaches case study. I have checked all the text.