### PR TITLE
fix higher order functions in reference manual expressions chapter

### DIFF
--- a/src/reference-manual/expressions.qmd
+++ b/src/reference-manual/expressions.qmd
@@ -1257,13 +1257,13 @@ or data. The second group of arguments, consisting of a real and integer
 array in all cases, must be expressions involving only data and
 literals.*
 
-  |                function |        parameter or data args        |           data args            |   return type   |
-  | ----------------------: | :----------------------------------: | :----------------------------: | :-------------: |
-  |        `algebra_solver` |           `vector, vector`           | `array [] real, array [] real` |    `vector`     |
-  | `algebra_solver_newton` |           `vector, vector`           | `array [] real, array [] real` |    `vector`     |
-  |         `integrate_1d`, |     `real, real, array [] real`      | `array [] real, array [] real` |     `real`      |
-  |      `integrate_ode_X`, | `real, array [] real, array [] real` | `array [] real, array [] real` | `array [] real` |
-  |              `map_rect` |           `vector, vector`           | `array [] real, array [] real` |    `vector`     |
+  |                function |        parameter or data args        |          data args            |   return type   |
+  | ----------------------: | :----------------------------------: | :---------------------------: | :-------------: |
+  |        `algebra_solver` |           `vector, vector`           | `array [] real, array [] int` |    `vector`     |
+  | `algebra_solver_newton` |           `vector, vector`           | `array [] real, array [] int` |    `vector`     |
+  |         `integrate_1d`, |     `real, real, array [] real`      | `array [] real, array [] int` |     `real`      |
+  |      `integrate_ode_X`, | `real, array [] real, array [] real` | `array [] real, array [] int` | `array[,] real` |
+  |              `map_rect` |           `vector, vector`           | `array [] real, array [] int` |    `vector`     |
 
 For example, the `integrate_ode_rk45` function can be used to integrate
 differential equations in Stan:
@@ -1274,7 +1274,7 @@ functions {
                     array [] real y,
                     array [] real theta,
                     array [] real x_r,
-                    array [] real x_i) {
+                    array [] int x_i) {
     // ...
   }
 }
@@ -1292,21 +1292,23 @@ array[T, 2] real y_hat = integrate_ode_rk45(foo, y0, t0,
 ```
 
 The function argument is `foo`, the name of the user-defined
-function;  as shown in the [higher-order functions table](#higher-order-functions),
+function;  as shown in the [higher-order functions table](#higher-order-functions-table),
 `integrate_ode_rk45` takes a real array, a real, three more real arrays, and
 an integer array as arguments and returns 2D real array.
 
 ##### Variadic Higher-order Functions Table {- #variadic-higher-order-functions-table}
 
-*Variadic Higher-order functions in Stan with their argument
-function types.  The first group of arguments are restricted in type.
-The sequence of trailing arguments can be of any length with any types.*
+*Variadic higher-order functions in Stan with the types of their
+non-variadic arguments (those following the function argument).  The
+trailing variadic arguments can be of any number and any types.*
 
-  |     function |        restricted args        | return type |
-  | -----------: | :---------------------------: | :---------: |
-  |    `solve_X` | `vector`                      | `vector`    |
-  |     `ode_X`, | `vector, real, array [] real` | `vector[]`  |
-  | `reduce_sum` |    ```array[] T, T1, T2```    |   `real`    |
+  |               function |            restricted args            |   return type     |
+  | ---------------------: | :-----------------------------------: | :---------------: |
+  |              `solve_X` | `vector`                              | `vector`          |
+  |                `ode_X` | `vector, real, array [] real`         | `array [] vector` |
+  |                `dae_X` | `vector, vector, real, array [] real` | `array [] vector` |
+  |        `integrate_1d_X`| `real, real`                          | `real`            |
+  |           `reduce_sum` | `array [] T, int`                     | `real`            |
 
 `T`, `T1`, and `T2` can be any Stan type.
 
@@ -1316,7 +1318,7 @@ differential equations in Stan:
 ```stan
 functions {
   vector foo(real t, vector y, real theta, vector beta,
-            array [] real x_i, int index) {
+            array [] int x_i, int index) {
     // ...
   }
 }
@@ -1330,14 +1332,14 @@ vector[7] beta;
 array[10] int x_i;
 int index;
 // ...
-vector[2] y_hat[T] = ode_rk45(foo, y0, t0, ts, theta,
-                              beta, x_i, index);
+array[T] vector[2] y_hat = ode_rk45(foo, y0, t0, ts, theta,
+                                    beta, x_i, index);
 ```
 
 The function argument is `foo`, the name of the user-defined
 function. As shown in the
 [variadic higher-order functions table](#variadic-higher-order-functions-table),
-`ode_rk45` takes a real, a vector, a real, a real array, and a sequence of
+`ode_rk45` takes a vector, a real, a real array, and a sequence of
 arguments whose types match those at the end of `foo` and returns an array of
 vectors.
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] Declare copyright holder and open-source license: see below

#### Summary

Fixes outdated syntax and errors in `reference-manual/expressions.qmd` in the two higher-order-functions tables (and their worked examples), and adds the missing variadic higher-order functions.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Aki Vehtari

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)

#### AI Use Disclosure

Fixed by Claude which compared the functions reference to the tables and examples. I checked the edits.