### PR TITLE
Added paragraph about NUTS and stepsize_jitter.

### DIFF
--- a/src/cmdstan-guide/mcmc_config.qmd
+++ b/src/cmdstan-guide/mcmc_config.qmd
@@ -474,6 +474,15 @@ The default argument is `max_depth=10`.
 In the case where a model has a difficult posterior from which to sample,
 `max_depth` should be increased to ensure that that the NUTS tree can grow as large as necessary.
 
+The [notes about `stepsize_jitter`](https://mc-stan.org/docs/cmdstan-guide/mcmc_config.html#step-size) 
+with `engine=hmc` apply to NUTS, as well.
+Symptoms of a sampler stuck in a zone of high curvature include an acceptance rate and 
+number of leapfrog steps consistently near zero, as well as a tree depth that never goes deeper than two.
+The recommended solution is to reparameterize the model to eliminate all such zones.
+If that is infeasible, and warm-up samples are free of the symptoms visible during the sampling phase,
+a non-zero `stepsize_jitter` may allow NUTS to free itself from a local zone of high curvature.
+Beware that large values will degrade sampler performance.
+
 When the argument `engine=static` is specified,
 the user must specify the integration time via keyword `int_time`
 which takes as a value a positive number.


### PR DESCRIPTION
#### Submission Checklist

- [N/A] Builds locally
- [N/A] New functions marked with `` <<{ since VERSION }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Encountered a situation where `stepsize_jitter` came in handy while sampling with NUTS. Added a paragraph to the CmdStan documentation outlining when users might want to consider using a value other than the default. Related to [a thread](https://discourse.mc-stan.org/t/debugging-a-stuck-sampler-on-a-complex-ish-model/) on the Stan discussion forum.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): hjhornbeck

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)
