### PR TITLE
Document `laplace_latent_solve(_tol)`

### DIFF
--- a/src/functions-reference/embedded_laplace.qmd
+++ b/src/functions-reference/embedded_laplace.qmd
@@ -341,9 +341,9 @@ and allows the user to tune the control parameters of the approximation.
 
 ## Return the approximate conditional mean and Cholesky factor
 
-When the parameters of the Gaussian approximation are needed directly,
-rather than a random draw from it, use `laplace_latent_solve`.
-This returns a tuple containing:
+In `generated quantities`, when the parameters of the Gaussian approximation
+are needed directly, rather than a random draw from it, use
+`laplace_latent_solve`. This returns a tuple containing:
 
 1. the posterior mean of the Laplace approximation to $p(\theta \mid y, \phi)$, and
 2. the lower-triangular Cholesky factor of the posterior covariance of that
@@ -359,7 +359,7 @@ the signature for `laplace_marginal`:
 
 Returns the posterior mean and the lower-triangular Cholesky factor of the
 posterior covariance from the Laplace approximation to
-$p(\theta \mid y, \phi)$.
+$p(\theta \mid y, \phi)$; may only be used in the generated quantities block.
 
 {{< since 2.40 >}}
 
@@ -374,7 +374,7 @@ specified with a `_tol` variant:
 Returns the posterior mean and the lower-triangular Cholesky factor of the
 posterior covariance from the Laplace approximation to
 $p(\theta \mid y, \phi)$, and allows the user to tune the control parameters
-of the approximation.
+of the approximation; may only be used in the generated quantities block.
 
 {{< since 2.40 >}}
 

--- a/src/functions-reference/embedded_laplace.qmd
+++ b/src/functions-reference/embedded_laplace.qmd
@@ -315,6 +315,9 @@ Create a default Laplace options tuple containing `theta_init`.
 
 In `generated quantities`, it is possible to sample from the Laplace
 approximation of $p(\theta \mid \phi, y)$ using `laplace_latent_rng`.
+To obtain the approximate mean and Cholesky factor of the covariance
+instead of a random draw, see
+[`laplace_latent_solve`](#return-the-approximate-conditional-mean-and-cholesky-factor).
 The signature for `laplace_latent_rng` follows closely
 the signature for `laplace_marginal`:
 
@@ -335,6 +338,53 @@ Once again, it is possible to specify control parameters:
 Samples from the approximate conditional posterior $p(\theta \mid y, \phi)$
 and allows the user to tune the control parameters of the approximation.
 {{< since 2.39 >}}
+
+## Return the approximate conditional mean and Cholesky factor
+
+When the parameters of the Gaussian approximation are needed directly,
+rather than a random draw from it, use `laplace_latent_solve`.
+This returns a tuple containing:
+
+1. the posterior mean of the Laplace approximation to $p(\theta \mid y, \phi)$, and
+2. the lower-triangular Cholesky factor of the posterior covariance of that
+   approximation.
+
+The signature for `laplace_latent_solve` follows closely
+the signature for `laplace_marginal`:
+
+<!-- tuple(vector, matrix); laplace_latent_solve; (function likelihood_function, tuple(...) likelihood_arguments, int hessian_block_size, function covariance_function, tuple(...) covariance_arguments); -->
+\index{{\tt \bfseries laplace\_latent\_solve }!{\tt (function likelihood\_function, tuple(...) likelihood\_arguments, int hessian\_block\_size, function covariance\_function, tuple(...) covariance\_arguments): tuple(vector, matrix)}|hyperpage}
+
+`tuple(vector, matrix)` **`laplace_latent_solve`**`(function likelihood_function, tuple(...) likelihood_arguments, int hessian_block_size, function covariance_function, tuple(...) covariance_arguments)`<br>\newline
+
+Returns the posterior mean and the lower-triangular Cholesky factor of the
+posterior covariance from the Laplace approximation to
+$p(\theta \mid y, \phi)$.
+{{< since 2.40 >}}
+
+As with the other embedded Laplace functions, control parameters can be
+specified with a `_tol` variant:
+
+<!-- tuple(vector, matrix); laplace_latent_solve_tol; (function likelihood_function, tuple(...) likelihood_arguments, int hessian_block_size, function covariance_function, tuple(...) covariance_arguments, tuple(vector, real, int, int, int, int) tolerances); -->
+\index{{\tt \bfseries laplace\_latent\_solve\_tol }!{\tt (function likelihood\_function, tuple(...) likelihood\_arguments, int hessian\_block\_size, function covariance\_function, tuple(...) covariance\_arguments, tuple(vector, real, int, int, int, int) tolerances): tuple(vector, matrix)}|hyperpage}
+
+`tuple(vector, matrix)` **`laplace_latent_solve_tol`**`(function likelihood_function, tuple(...), int hessian_block_size, function covariance_function, tuple(...), tuple(vector, real, int, int, int, int) tolerances)`<br>\newline
+
+Returns the posterior mean and the lower-triangular Cholesky factor of the
+posterior covariance from the Laplace approximation to
+$p(\theta \mid y, \phi)$, and allows the user to tune the control parameters
+of the approximation.
+{{< since 2.40 >}}
+
+The returned tuple can be unpacked with Stan's tuple indexing, for example:
+
+```stan
+tuple(vector[N], matrix[N, N]) mean_chol
+    = laplace_latent_solve(ll_function, (a, y), hessian_block_size,
+                           cov_function, (rho, alpha, x, N, delta));
+vector[N] mu = mean_chol.1;
+matrix[N, N] L = mean_chol.2;
+```
 
 ## Built-in Laplace marginal likelihood functions
 

--- a/src/functions-reference/embedded_laplace.qmd
+++ b/src/functions-reference/embedded_laplace.qmd
@@ -359,7 +359,7 @@ the signature for `laplace_marginal`:
 
 Returns the posterior mean and the lower-triangular Cholesky factor of the
 posterior covariance from the Laplace approximation to
-$p(\theta \mid y, \phi)$; may only be used in the generated quantities block.
+$p(\theta \mid y, \phi)$; may only be used in the generated quantities block or with all-`data` arguments to the likelihood and covariance functions.
 
 {{< since 2.40 >}}
 

--- a/src/functions-reference/embedded_laplace.qmd
+++ b/src/functions-reference/embedded_laplace.qmd
@@ -381,11 +381,11 @@ of the approximation.
 The returned tuple can be unpacked with Stan's tuple indexing, for example:
 
 ```stan
-tuple(vector[N], matrix[N, N]) mean_chol
-    = laplace_latent_solve(ll_function, (a, y), hessian_block_size,
-                           cov_function, (rho, alpha, x, N, delta));
-vector[N] mu = mean_chol.1;
-matrix[N, N] L = mean_chol.2;
+vector[N] mu;
+matrix[N, N] L;
+
+(mu, L) = laplace_latent_solve(ll_function, (a, y), hessian_block_size,
+                               cov_function, (rho, alpha, x, N, delta));
 ```
 
 ## Built-in Laplace marginal likelihood functions

--- a/src/functions-reference/embedded_laplace.qmd
+++ b/src/functions-reference/embedded_laplace.qmd
@@ -360,6 +360,7 @@ the signature for `laplace_marginal`:
 Returns the posterior mean and the lower-triangular Cholesky factor of the
 posterior covariance from the Laplace approximation to
 $p(\theta \mid y, \phi)$.
+
 {{< since 2.40 >}}
 
 As with the other embedded Laplace functions, control parameters can be
@@ -374,6 +375,7 @@ Returns the posterior mean and the lower-triangular Cholesky factor of the
 posterior covariance from the Laplace approximation to
 $p(\theta \mid y, \phi)$, and allows the user to tune the control parameters
 of the approximation.
+
 {{< since 2.40 >}}
 
 The returned tuple can be unpacked with Stan's tuple indexing, for example:

--- a/src/functions-reference/functions_index.qmd
+++ b/src/functions-reference/functions_index.qmd
@@ -1742,6 +1742,16 @@ pagetitle: Alphabetical Index
  - <div class='index-container'>[`(function likelihood_function, tuple(...) likelihood_arguments, int hessian_block_size, function covariance_function, tuple(...) covariance_arguments) : vector`](embedded_laplace.qmd#index-entry-60d4efd35a460871aff97a758f5d366faee26465) <span class='detail'>(embedded_laplace.html)</span></div>
 
 
+<a id='laplace_latent_solve' href='#laplace_latent_solve' class='anchored unlink'>**laplace_latent_solve**:</a>
+
+ - <div class='index-container'>[`(function likelihood_function, tuple(...) likelihood_arguments, int hessian_block_size, function covariance_function, tuple(...) covariance_arguments) : tuple(vector, matrix)`](embedded_laplace.qmd#index-entry-81b0a183fcf12a6986f0736b373ce211aed2fc77) <span class='detail'>(embedded_laplace.html)</span></div>
+
+
+<a id='laplace_latent_solve_tol' href='#laplace_latent_solve_tol' class='anchored unlink'>**laplace_latent_solve_tol**:</a>
+
+ - <div class='index-container'>[`(function likelihood_function, tuple(...) likelihood_arguments, int hessian_block_size, function covariance_function, tuple(...) covariance_arguments, tuple(vector, real, int, int, int, int) tolerances) : tuple(vector, matrix)`](embedded_laplace.qmd#index-entry-1dcf9701db2ac630332a16b39610117eff866f6a) <span class='detail'>(embedded_laplace.html)</span></div>
+
+
 <a id='laplace_latent_tol_bernoulli_logit_rng' href='#laplace_latent_tol_bernoulli_logit_rng' class='anchored unlink'>**laplace_latent_tol_bernoulli_logit_rng**:</a>
 
  - <div class='index-container'>[`(array[] int y, array[] int y_index, vector m, data int hessian_block_size, function covariance_function, tuple(...) covariance_arguments, tuple(vector, real, int, int, int, int) tolerances) : vector`](embedded_laplace.qmd#index-entry-4566ad7c6cd5f0ee057539a6e2a0bea28554f082) <span class='detail'>(embedded_laplace.html)</span></div>


### PR DESCRIPTION
#### Submission Checklist

- [x] Builds locally
- [x] New functions marked with `` <<{ since 2.40 }>>``
- [x] Declare copyright holder and open-source license: see below

#### Summary

Document `laplace_latent_solve` and `laplace_latent_solve_tol` in the Functions Reference.
Added a new section "Return the approximate conditional mean and Cholesky factor" to `embedded_laplace.qmd`.
Corresponding PRs in
 + math [#3337](https://github.com/stan-dev/math/pull/3337)
 + stanc3 [#1649](https://github.com/stan-dev/stanc3/pull/1649)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Aalto University


By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC BY-ND 4.0 (https://creativecommons.org/licenses/by-nd/4.0/)

This PR used AI Assistance (Cursor).